### PR TITLE
Fix karpenter file

### DIFF
--- a/2024/kubernetes/customer-karpenter.yaml
+++ b/2024/kubernetes/customer-karpenter.yaml
@@ -21,10 +21,10 @@ spec:
             nodeClassRef:
                 name: default
     limits:
-        cpu: 500m
+        cpu: 5000m
     disruption:
         consolidationPolicy: WhenUnderutilized
-        expireAfter: 720h # 30 * 24h = 720h
+        expireAfter: 10m
 ---
 apiVersion: karpenter.k8s.aws/v1beta1
 kind: EC2NodeClass


### PR DESCRIPTION
카펜터 설정에서 최대 CPU 할당량을 생성하고자 하는 pod 의 필요 cpu 양과 동일하게 설정하여 오류가 발생했던 것으로 확인됐습니다.