### PR TITLE
Update api_setting.sh

### DIFF
--- a/2024/api_setting.sh
+++ b/2024/api_setting.sh
@@ -9,6 +9,11 @@ read customer_api
 cd "$customer_directory"
 
 for file in *.html; do
+    backup_file="${file}.backup"
+    if [ -f "$backup_file" ]; then
+        cp "$backup_file" "$file"
+    fi
+    cp "$file" "$backup_file"
     sed -i "s|YOUR_API_URL|$customer_api|g" "$file"
 done
 
@@ -18,5 +23,10 @@ read employee_api
 cd "$employee_directory"
 
 for file in *.html; do
+    backup_file="${file}.backup"
+    if [ -f "$backup_file" ]; then
+        cp "$backup_file" "$file"
+    fi
+    cp "$file" "$backup_file"
     sed -i "s|YOUR_API_URL|$employee_api|g" "$file"
 done


### PR DESCRIPTION
기존 코드는 한번 API를 교체 시 더이상 파일 내에 YOUR_API_URL이 존재하지 않아, 만약 API URL을 잘못 입력했을 경우 다시 git clone을 해와야 할 필요가 있었습니다.

때문에 기존 YOUR_API_URL 파일을 backup하고, 매번 쉘스크립트 실행 시 마다 backup파일을 덮어씌워 계속해서 YOUR_API_URL이 존재할 수 있도록 했습니다.