### PR TITLE
EKS 실습 2차 수정

### DIFF
--- a/2025/cloudformation/MonolithicApp_CF.yaml
+++ b/2025/cloudformation/MonolithicApp_CF.yaml
@@ -342,6 +342,7 @@ Resources:
   # Standard MySQL Instance
   MySQLDBInstance:
     Type: AWS::RDS::DBInstance
+    DeletionPolicy: Delete
     Properties:
       DBInstanceIdentifier: monolithic-mysql
       Engine: mysql

--- a/2025/cloudformation/MonolithicApp_CF.yaml
+++ b/2025/cloudformation/MonolithicApp_CF.yaml
@@ -262,9 +262,9 @@ Resources:
             npm install
 
             mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
-            "SELECT COUNT(*) FROM mysql.user WHERE user = 'nodeapp'\G" | grep -q 'COUNT(*): 0' && \
+            "SELECT COUNT(*) AS cnt FROM mysql.user WHERE user = 'nodeapp' AND host = '%'\G" | grep -q 'cnt: 0' && \
             mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
-            "CREATE USER 'nodeapp' IDENTIFIED WITH mysql_native_password BY 'coffee';"
+            "CREATE USER 'nodeapp'@'%' IDENTIFIED BY 'coffee';"
 
             mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
             "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER ON *.* TO 'nodeapp'@'%' WITH GRANT OPTION;"

--- a/2025/cloudformation/MonolithicApp_CF.yaml
+++ b/2025/cloudformation/MonolithicApp_CF.yaml
@@ -1,28 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Samsung Cloud Arch MonolithicApp (Standard MySQL)
 
-Parameters:
-  MaxECSServiceTasks:
-    Type: Number
-    MaxValue: 6
-    MinValue: 1
-    Default: 4
-    Description: The maximum number of ECS Tasks allowed at a Service
-
-  MaxECSClusterTasks:
-    Type: Number
-    MaxValue: 8
-    MinValue: 1
-    Default: 6
-    Description: The maximum number of ECS Tasks allowed at a Cluster
-
-  MaxECSClusterServices:
-    Type: Number
-    MaxValue: 2
-    MinValue: 1
-    Default: 2
-    Description: The maximum number of ECS Services allowed at a Cluster
-
 Mappings:
   RegionMap:
     us-east-1:

--- a/2025/cloudformation/MonolithicApp_CF.yaml
+++ b/2025/cloudformation/MonolithicApp_CF.yaml
@@ -68,7 +68,7 @@ Resources:
               - ecs:RegisterTaskDefinition
               - ecs:ListTaskDefinitions
               - ecs:DescribeTaskDefinition
-            Resource: '*'
+            Resource: "*"
           - Effect: Allow
             Action:
               - iam:PassRole
@@ -91,7 +91,7 @@ Resources:
               - sts:AssumeRole
 
   # VPC and Networking
-  LabVPC:
+  MonolithicVPC:
     Type: AWS::EC2::VPC
     Properties:
       CidrBlock: 10.16.0.0/16
@@ -99,55 +99,55 @@ Resources:
       EnableDnsHostnames: true
       Tags:
         - Key: Name
-          Value: LabVPC
+          Value: MonolithicVPC
 
   IGW:
     Type: AWS::EC2::InternetGateway
     Properties:
       Tags:
         - Key: Name
-          Value: LabIGW
+          Value: MonolithicIGW
 
   AttachGateway:
     Type: AWS::EC2::VPCGatewayAttachment
     Properties:
-      VpcId: !Ref LabVPC
+      VpcId: !Ref MonolithicVPC
       InternetGatewayId: !Ref IGW
 
   PublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref LabVPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      VpcId: !Ref MonolithicVPC
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: 10.16.10.0/24
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
           Value: Public Subnet 1
         - Key: kubernetes.io/role/elb
-          Value: '1'
+          Value: "1"
         - Key: karpenter.sh/discovery
           Value: coffee-supplier
 
   PublicSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref LabVPC
-      AvailabilityZone: !Select [ 1, !GetAZs '' ]
+      VpcId: !Ref MonolithicVPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: 10.16.20.0/24
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
           Value: Public Subnet 2
         - Key: kubernetes.io/role/elb
-          Value: '1'
+          Value: "1"
         - Key: karpenter.sh/discovery
           Value: coffee-supplier
 
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref LabVPC
+      VpcId: !Ref MonolithicVPC
       Tags:
         - Key: Name
           Value: Public Route Table
@@ -174,8 +174,8 @@ Resources:
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref LabVPC
-      AvailabilityZone: !Select [ 0, !GetAZs '' ]
+      VpcId: !Ref MonolithicVPC
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: 10.16.30.0/24
       Tags:
         - Key: Name
@@ -184,8 +184,8 @@ Resources:
   PrivateSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
-      VpcId: !Ref LabVPC
-      AvailabilityZone: !Select [ 1, !GetAZs '' ]
+      VpcId: !Ref MonolithicVPC
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: 10.16.40.0/24
       Tags:
         - Key: Name
@@ -194,7 +194,7 @@ Resources:
   PrivateRouteTable1:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref LabVPC
+      VpcId: !Ref MonolithicVPC
       Tags:
         - Key: Name
           Value: Private Route Table 1
@@ -202,7 +202,7 @@ Resources:
   PrivateRouteTable2:
     Type: AWS::EC2::RouteTable
     Properties:
-      VpcId: !Ref LabVPC
+      VpcId: !Ref MonolithicVPC
       Tags:
         - Key: Name
           Value: Private Route Table 2
@@ -228,7 +228,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              Service: [ ec2.amazonaws.com ]
+              Service: [ec2.amazonaws.com]
             Action: sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AdministratorAccess
@@ -244,7 +244,7 @@ Resources:
     Type: AWS::EC2::SecurityGroup
     Properties:
       GroupDescription: Allow HTTP and SSH
-      VpcId: !Ref LabVPC
+      VpcId: !Ref MonolithicVPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
@@ -262,7 +262,7 @@ Resources:
       LaunchTemplateData:
         IamInstanceProfile:
           Name: !Ref myEc2InstanceProfile
-        ImageId: !FindInMap [ RegionMap, !Ref AWS::Region, Ubuntu24 ]
+        ImageId: !FindInMap [RegionMap, !Ref AWS::Region, Ubuntu24]
         InstanceType: t2.micro
         NetworkInterfaces:
           - AssociatePublicIpAddress: true
@@ -283,10 +283,28 @@ Resources:
             cd architect-cloud/2025/monolithic_code
             npm install
 
-            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e "CREATE USER 'nodeapp' IDENTIFIED WITH mysql_native_password BY 'coffee'"
-            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER ON *.* TO 'nodeapp'@'%' WITH GRANT OPTION;"
-            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e "CREATE DATABASE COFFEE;"
-            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e "USE COFFEE; CREATE TABLE suppliers(id INT NOT NULL AUTO_INCREMENT, name VARCHAR(255) NOT NULL, address VARCHAR(255) NOT NULL, city VARCHAR(255) NOT NULL, state VARCHAR(255) NOT NULL, email VARCHAR(255) NOT NULL, phone VARCHAR(100) NOT NULL, PRIMARY KEY (id));"
+            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
+            "SELECT COUNT(*) FROM mysql.user WHERE user = 'nodeapp'\G" | grep -q 'COUNT(*): 0' && \
+            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
+            "CREATE USER 'nodeapp' IDENTIFIED WITH mysql_native_password BY 'coffee';"
+
+            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
+            "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, PROCESS, REFERENCES, INDEX, ALTER, SHOW DATABASES, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER ON *.* TO 'nodeapp'@'%' WITH GRANT OPTION;"
+
+            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -e \
+            "CREATE DATABASE IF NOT EXISTS COFFEE;"
+
+            mysql -u admin -plab-password -h ${MySQLDBInstance.Endpoint.Address} -P 3306 -D COFFEE -e \
+            "CREATE TABLE IF NOT EXISTS suppliers(
+                id INT NOT NULL AUTO_INCREMENT,
+                name VARCHAR(255) NOT NULL,
+                address VARCHAR(255) NOT NULL,
+                city VARCHAR(255) NOT NULL,
+                state VARCHAR(255) NOT NULL,
+                email VARCHAR(255) NOT NULL,
+                phone VARCHAR(100) NOT NULL,
+                PRIMARY KEY (id)
+            );"
 
             sed -i "s|REPLACE-DB-HOST|${MySQLDBInstance.Endpoint.Address}|g" /home/ubuntu/architect-cloud/2025/monolithic_code/app/config/config.js
             sed -i "s|REPLACE-DB-HOST|${MySQLDBInstance.Endpoint.Address}|g" /home/ubuntu/architect-cloud/2025/microservice/customer/app/config/config.js
@@ -333,7 +351,7 @@ Resources:
     Properties:
       GroupName: DBSecurityGroup
       GroupDescription: Enable MySQL access
-      VpcId: !Ref LabVPC
+      VpcId: !Ref MonolithicVPC
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 3306
@@ -349,7 +367,7 @@ Resources:
     Properties:
       DBInstanceIdentifier: monolithic-mysql
       Engine: mysql
-      EngineVersion: "8.0.32"
+      EngineVersion: "8.0.42"
       DBInstanceClass: db.t3.micro
       AllocatedStorage: "20"
       StorageType: gp2
@@ -360,7 +378,7 @@ Resources:
         - !Ref DBSecurityGroup
       MasterUsername: admin
       MasterUserPassword: lab-password
-      BackupRetentionPeriod: 7
+      BackupRetentionPeriod: 0
       AutoMinorVersionUpgrade: true
       Tags:
         - Key: Name
@@ -369,6 +387,6 @@ Resources:
 Outputs:
   MySQLEndpoint:
     Description: Endpoint of the MySQL instance
-    Value: !GetAtt [ MySQLDBInstance, Endpoint.Address ]
+    Value: !GetAtt [MySQLDBInstance, Endpoint.Address]
     Export:
       Name: MonolithicMySQLEndpoint

--- a/2025/cloudformation/ServerlessApp_CF.yaml
+++ b/2025/cloudformation/ServerlessApp_CF.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: '2010-09-09'
+AWSTemplateFormatVersion: "2010-09-09"
 
 Resources:
   LabVPC:
@@ -38,7 +38,7 @@ Resources:
       AvailabilityZone:
         Fn::Select:
           - 0
-          - Fn::GetAZs: ''
+          - Fn::GetAZs: ""
       CidrBlock: 10.16.10.0/24
       MapPublicIpOnLaunch: true
       Tags:
@@ -51,8 +51,8 @@ Resources:
       VpcId: !Ref LabVPC
       AvailabilityZone:
         Fn::Select:
-        - 1
-        - Fn::GetAZs: ''
+          - 1
+          - Fn::GetAZs: ""
       CidrBlock: 10.16.20.0/24
       MapPublicIpOnLaunch: true
       Tags:
@@ -70,8 +70,8 @@ Resources:
     Properties:
       VpcId: !Ref LabVPC
       Tags:
-      - Key: Name
-        Value: Public Route Table
+        - Key: Name
+          Value: Public Route Table
 
   PublicRoute:
     Type: AWS::EC2::Route
@@ -175,7 +175,7 @@ Resources:
   # RDS Database
   ###########
   DBSubnetGroup:
-    Type: 'AWS::RDS::DBSubnetGroup'
+    Type: "AWS::RDS::DBSubnetGroup"
     Properties:
       DBSubnetGroupDescription: "Subnet group for RDS"
       SubnetIds:
@@ -183,13 +183,14 @@ Resources:
         - !Ref PublicSubnet2
 
   MyDBInstance:
-    Type: 'AWS::RDS::DBInstance'
+    Type: "AWS::RDS::DBInstance"
+    DeletionPolicy: Delete
     DependsOn: AttachGateway
     Properties:
       DBInstanceIdentifier: supplierdb
       DBInstanceClass: db.t3.micro
       Engine: mysql
-      EngineVersion: '8.0.35'
+      EngineVersion: "8.0.42"
       MasterUsername: nodeapp
       MasterUserPassword: lab-password
       DBName: COFFEE
@@ -207,7 +208,7 @@ Resources:
           Value: MyDatabaseInstance
 
   MyDBSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
+    Type: "AWS::EC2::SecurityGroup"
     Properties:
       GroupDescription: Security group for RDS instance
       VpcId: !Ref LabVPC
@@ -221,4 +222,3 @@ Outputs:
   DBInstanceEndpoint:
     Description: "The endpoint address of the RDS instance"
     Value: !GetAtt MyDBInstance.Endpoint.Address
-  

--- a/2025/kubernetes/coffee-ingress.yaml
+++ b/2025/kubernetes/coffee-ingress.yaml
@@ -22,4 +22,4 @@ spec:
               service:
                 name: employee
                 port:
-                  number: 8080
+                  number: 8081

--- a/2025/kubernetes/employee-rs.yaml
+++ b/2025/kubernetes/employee-rs.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-    name: employee
+  name: employee
 spec:
-    replicas: 2
-    selector:
-        matchLabels:
-            app: employee
-    template:
-        metadata:
-            labels:
-                app: employee
-        spec:
-            hostNetwork: true
-            containers:
-                - name: employee
-                  image: $ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/employee
-                  ports:
-                      - containerPort: 8080
-                        protocol: TCP
+  replicas: 2
+  selector:
+    matchLabels:
+      app: employee
+  template:
+    metadata:
+      labels:
+        app: employee
+    spec:
+      hostNetwork: true
+      containers:
+        - name: employee
+          image: $ACCOUNT_ID.dkr.ecr.us-west-2.amazonaws.com/employee
+          ports:
+            - containerPort: 8081
+              protocol: TCP

--- a/2025/microservice/customer/Dockerfile
+++ b/2025/microservice/customer/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11-alpine
+FROM node:22-alpine
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . .

--- a/2025/microservice/employee/Dockerfile
+++ b/2025/microservice/employee/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:11-alpine
+FROM node:22-alpine
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY . .

--- a/2025/microservice/employee/index.js
+++ b/2025/microservice/employee/index.js
@@ -140,7 +140,7 @@ app.use(function (req, res, next) {
 });
 
 // set port, listen for requests
-const app_port = process.env.APP_PORT || 8080;
+const app_port = process.env.APP_PORT || 8081;
 app.listen(app_port, () => {
 	console.log(`Server is running on port ${app_port}.`);
 });

--- a/2025/utils/create_eksctl_yaml.sh
+++ b/2025/utils/create_eksctl_yaml.sh
@@ -92,10 +92,10 @@ cat >> $CONFIG_FILE <<EOF
 
 nodeGroups:
   - name: coffee-supplier-node-group
-    instanceType: t3.small
-    desiredCapacity: 3
-    minSize: 3
-    maxSize: 6
+    instanceType: t3.medium
+    desiredCapacity: 2
+    minSize: 2
+    maxSize: 2
     privateNetworking: false
 EOF
 

--- a/2025/utils/create_eksctl_yaml.sh
+++ b/2025/utils/create_eksctl_yaml.sh
@@ -7,12 +7,12 @@ CLUSTER_NAME="coffee-supplier"
 CLUSTER_VERSION='1.33'
 KARPENTER_VERSION='1.5.0'
 REGION="us-west-2"
-VPC_NAME="LabVPC"
+VPC_NAME="MonolithicVPC"
 
 
 echo "🔍 Searching for VPC with Name tag: $VPC_NAME in region: $REGION..."
 
-# VPC ID 자동 검색 (태그 Name이 LabVPC인 경우)
+# VPC ID 자동 검색
 VPC_ID=$(aws ec2 describe-vpcs \
   --region "$REGION" \
   --filters "Name=tag:Name,Values=$VPC_NAME" \

--- a/2025/utils/install_alb_to_eks.sh
+++ b/2025/utils/install_alb_to_eks.sh
@@ -4,7 +4,6 @@ set -e
 # 변수 설정
 CLUSTER_NAME="coffee-supplier"
 REGION="us-west-2"
-VPC_NAME="LabVPC"
 
 echo "🔧 Helm 설치 중..."
 curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3


### PR DESCRIPTION
이 Pull Request는 인프라 설정 개선, 종속성 업데이트, 자원 사용 최적화를 위한 여러 파일의 변경사항을 포함합니다.
주요 변경 사항은 리소스 이름 일관성 확보, 데이터베이스 초기화 스크립트 개선, 종속성 업그레이드, Kubernetes 및 EKS 설정 변경 등입니다.

### ✅ 인프라스트럭처 관련 변경 사항:
* `2025/cloudformation/MonolithicApp_CF.yaml` 및 관련 리소스 내의 모든 `LabVPC` 명칭을 `MonolithicVPC`로 변경하여 애플리케이션 네이밍 컨벤션과 일치시킴 [[1]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL94-R128) [[2]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL177-R156) [[3]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL187-R166) [[4]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL197-R183) [[5]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL247-R225) [[6]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL336-R332)
* MySQL 데이터베이스 구성을 `EngineVersion` 8.0.42로 변경, `DeletionPolicy: Delete` 추가, `BackupRetentionPeriod`를 0으로 설정하여 비용 최적화 [[1]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fR345-R349) [[2]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL363-R360)
* MySQL 초기화 스크립트 개선 – 사용자 및 데이터베이스 생성 시 존재 여부를 확인하여 반복 실행 가능(idempotent)하도록 변경

### ☸️ Kubernetes 및 EKS 설정 변경:
* `employee` 서비스 포트를 8080에서 8081로 변경하여 애플리케이션 구성과 일치시킴 (`2025/kubernetes/coffee-ingress.yaml`, `employee-rs.yaml`) [[1]](diffhunk://#diff-e5150853607c1c71c4e4a448b0461017fbdc0478fe9d500df13d3a343b3bef74L25-R25) [[2]](diffhunk://#diff-af11267a562c31ff7c38fea3dea9276319d094f2d8d4afd36e721ee8a3e7e1d1L20-R20)
* EKS 노드 그룹 인스턴스 타입을 `t3.medium`으로 변경하고 용량(capacity) 조정으로 리소스 할당 최적화

### 📦 종속성 업데이트:
* `customer` 및 `employee` 마이크로서비스의 `Dockerfile`에서 Node.js 베이스 이미지를 버전 11에서 22로 업그레이드하여 성능 및 보안 향상 [[1]](diffhunk://#diff-738a00da0bca441dbb822a954c3ce1cedb8d2e9f30e0b1b8116e92a3b4232997L1-R1) [[2]](diffhunk://#diff-738a00da0bca441dbb822a954c3ce1cedb8d2e9f30e0b1b8116e92a3b4232997L1-R1)

### 🧹 기타 변경사항:
* CloudFormation 템플릿 전반에서 작은 따옴표를 큰 따옴표로 변경하고 들여쓰기 통일 등 YAML 포맷 표준화 [[1]](diffhunk://#diff-9d43899b164c5112c03cd66adedab9e49860f43dcd7df8d38f3d06916fa13e1fL71-R49) [[2]](diffhunk://#diff-b84f533819804e58838d740783def4ad53a4c460fff9a45a689a9d42134300f8L1-R1) [[3]](diffhunk://#diff-b84f533819804e58838d740783def4ad53a4c460fff9a45a689a9d42134300f8L41-R41) [[4]](diffhunk://#diff-b84f533819804e58838d740783def4ad53a4c460fff9a45a689a9d42134300f8L55-R55) [[5]](diffhunk://#diff-b84f533819804e58838d740783def4ad53a4c460fff9a45a689a9d42134300f8L178-R193) [[6]](diffhunk://#diff-b84f533819804e58838d740783def4ad53a4c460fff9a45a689a9d42134300f8L210-R211)
* `create_eksctl_yaml.sh`, `install_alb_to_eks.sh` 스크립트 내 VPC 이름을 `MonolithicVPC`로 수정하여 네이밍 일관성 유지 [[1]](diffhunk://#diff-f955c9e575012548e02217c96894eb559b62f4781160c76ac50cba010a0ef725L10-R15) [[2]](diffhunk://#diff-e750fc136288082032dc11622a9c53bac6db7f9a6124ee502d796d91fb2ab266L7)
