### PR TITLE
Update index.js to use caching

### DIFF
--- a/2025/monolithic_code/index.js
+++ b/2025/monolithic_code/index.js
@@ -7,6 +7,11 @@ const app = express();
 const mustacheExpress = require("mustache-express");
 const favicon = require("serve-favicon");
 const https = require("https");
+
+// --- 캐시 데이터 저장을 위한 변수 ---
+// 서버 정보를 저장할 객체를 선언합니다.
+let serverInfoCache = {};
+
 // parse requests of content-type: application/json
 app.use(bodyParser.json());
 // parse requests of content-type: application/x-www-form-urlencoded
@@ -19,8 +24,11 @@ app.set("views", __dirname + "/views");
 app.use(express.static("public"));
 app.use(favicon(__dirname + "/public/img/favicon.ico"));
 
+// --- 데이터 가져오는 함수들 (기존과 동일) ---
+
 // 메타데이터 토큰을 가져오는 함수
 async function fetchToken() {
+	// IMDSv2를 사용하기 위해 토큰을 먼저 요청합니다.
 	const response = await fetch("http://169.254.169.254/latest/api/token", {
 		method: "PUT",
 		headers: {
@@ -40,16 +48,19 @@ async function fetchMetadata(path, token) {
 		});
 
 		if (!response.ok) {
-			throw new Error(`Failed to fetch metadata: ${response.statusText}`);
+			// 메타데이터를 가져오지 못했을 경우, 'N/A'를 반환하여 에러를 방지합니다.
+			console.warn(`Failed to fetch metadata for ${path}: ${response.statusText}. Returning 'N/A'.`);
+			return "N/A";
 		}
 
 		return await response.text();
 	} catch (error) {
-		console.error("Error fetching metadata:", error.message);
-		throw error;
+		console.error(`Error fetching metadata for ${path}:`, error.message);
+		return "N/A"; // 에러 발생 시에도 'N/A'를 반환합니다.
 	}
 }
 
+// 외부 IP 및 지역 정보를 가져오는 함수
 function fetchIpInfo() {
 	return new Promise((resolve, reject) => {
 		const options = {
@@ -70,39 +81,44 @@ function fetchIpInfo() {
 					try {
 						const loc = JSON.parse(body);
 						const result = {
-							ip: loc.ip,
-							country: loc.country_name,
-							region: loc.region,
-							lat_long: `${loc.latitude}, ${loc.longitude}`,
-							timezone: loc.timezone,
+							ip: loc.ip || "N/A",
+							country: loc.country_name || "N/A",
+							region: loc.region || "N/A",
+							lat_long: (loc.latitude && loc.longitude) ? `${loc.latitude}, ${loc.longitude}`: "N/A",
+							timezone: loc.timezone || "N/A",
 						};
 						resolve(result);
 					} catch (error) {
+						// JSON 파싱 에러 처리
+						console.error("Error parsing IP info:", error);
 						reject(error);
 					}
 				});
 			})
 			.on("error", (error) => {
+				console.error("Error fetching IP info:", error);
 				reject(error);
 			});
 	});
 }
 
-// list all the suppliers
-app.get("/", async (req, res) => {
+// --- 서버 시작 시 캐시 초기화 ---
+// 서버가 시작될 때 한 번만 실행되어 메타데이터를 캐시에 저장합니다.
+async function initializeCache() {
+	console.log("Initializing metadata cache...");
 	try {
-		const token = await fetchToken(); // 토큰 가져옴
-		// 각 메타데이터 항목에 대한 요청을 비동기적으로 처리
+		const token = await fetchToken();
+		const ipInfo = await fetchIpInfo();
+
+		// 각 메타데이터 항목에 대한 요청을 병렬로 처리합니다.
 		const [instance_id, instance_type, avail_zone] = await Promise.all([
 			fetchMetadata("instance-id", token),
 			fetchMetadata("instance-type", token),
 			fetchMetadata("placement/availability-zone", token),
 		]);
 
-		const ipInfo = await fetchIpInfo();
-
-		// 모든 메타데이터를 받은 후 응답을 렌더링
-		res.render("home", {
+		// 가져온 정보를 serverInfoCache 객체에 저장합니다.
+		serverInfoCache = {
 			public_ip: ipInfo.ip,
 			instance_id: instance_id,
 			instance_type: instance_type,
@@ -111,11 +127,26 @@ app.get("/", async (req, res) => {
 			geo_region_name: ipInfo.region,
 			geo_lat_long: ipInfo.lat_long,
 			geo_timezone: ipInfo.timezone,
-		});
+		};
+
+		console.log("Metadata cache initialized successfully.");
+		console.log(serverInfoCache);
+
 	} catch (error) {
-		console.error("Error fetching EC2 metadata:", error);
-		res.status(500).send("Internal Server Error");
+		// 초기화 중 에러가 발생하면 콘솔에 로그를 남깁니다.
+		// 이 경우 앱은 빈 데이터로 시작하거나, 에러 처리를 추가할 수 있습니다.
+		console.error("Fatal error during cache initialization:", error);
+		// 필요한 경우, 프로세스를 종료할 수도 있습니다. process.exit(1);
 	}
+}
+
+
+// --- 라우터 설정 ---
+
+// list all the suppliers
+app.get("/", (req, res) => {
+	// 이제 네트워크 요청 대신 캐시된 객체에서 바로 데이터를 읽어옵니다.
+	res.render("home", serverInfoCache);
 });
 
 app.get("/health", (req, res) => {
@@ -139,8 +170,12 @@ app.use(function (req, res, next) {
 	res.status(404).render("404", {});
 });
 
-// set port, listen for requests
+// --- 서버 시작 ---
 const app_port = process.env.APP_PORT || 80;
-app.listen(app_port, () => {
-	console.log(`Server is running on port ${app_port}.`);
+
+// 서버 리스닝을 시작하기 전에 캐시를 먼저 초기화합니다.
+initializeCache().then(() => {
+	app.listen(app_port, () => {
+		console.log(`Server is running on port ${app_port}.`);
+	});
 });


### PR DESCRIPTION
기존 코드에서는 메타데이터 정보를 확인하기 위해 매번 메타데이터 요청을 수행했습니다.

이번 실습 최신화 도중 Internal Server Error가 계속 발생하게 되었고, 시간당 요청 수 제한을 초과했기 때문에 발생하는 문제로 나타났습니다.

웹서버를 Private Subnet에 생성하기 때문에, 다른 인스턴스를 생성해도 NAT Gateway의 Public IP가 같아 요청 수가 쌓여 이러한 문제가 발생하게 되었습니다.

실제 강의 환경에서는 각 실습을 한 번 씩만 진행하기에 문제가 없을 것으로 생각됩니다만, 혹시 모를 문제와 내년에 실습 내용을 비슷하게 가져가 최신화 작업이 필요할 경우가 있으면 반복될 수 있는 문제로 보여, 문제 해결을 위해 코드를 수정하였습니다.

때문에, 처음 서버 실행 시, 메타데이터를 가져와 캐싱해두고, 이후 새로고침을 진행해도 메타데이터 요청이 아니라 기존에 캐싱된 데이터를 사용하도록 수정되었습니다.

또한 혹시 모를 에러가 발생했을 경우 메타데이터 대신 N/A를 표시하도록 했습니다.