### PR TITLE
eksctl 및 kubectl 설치 경로 변경

### DIFF
--- a/2025/utils/install_k8s.sh
+++ b/2025/utils/install_k8s.sh
@@ -1,16 +1,26 @@
 #!/bin/bash
 
-#install kubectl
-echo "INSTALL kubectl for eks 1.33.0"
-sudo curl --silent --location -o /usr/local/bin/kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.33.0/2025-05-01/bin/linux/amd64/kubectl
-sudo chmod +x /usr/local/bin/kubectl
-kubectl version
+# Set install path
+INSTALL_DIR="$HOME/.local/bin"
+mkdir -p "$INSTALL_DIR"
 
-#install eksctl
+# Add to PATH if not already present
+if ! grep -q "$INSTALL_DIR" ~/.bashrc; then
+  echo "export PATH=\"\$PATH:$INSTALL_DIR\"" >> ~/.bashrc
+fi
+
+# install kubectl
+echo "INSTALL kubectl for eks 1.33.0"
+curl --silent --location -o "$INSTALL_DIR/kubectl" https://s3.us-west-2.amazonaws.com/amazon-eks/1.33.0/2025-05-01/bin/linux/amd64/kubectl
+chmod +x "$INSTALL_DIR/kubectl"
+"$INSTALL_DIR/kubectl" version --client
+
+# install eksctl
 echo "INSTALL eksctl"
 curl --silent --location "https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
-sudo mv -v /tmp/eksctl /usr/local/bin
-eksctl version
+mv -v /tmp/eksctl "$INSTALL_DIR/eksctl"
+chmod +x "$INSTALL_DIR/eksctl"
+"$INSTALL_DIR/eksctl" version
 
-#set $ACCOUNT_ID
+# set $ACCOUNT_ID
 echo 'export ACCOUNT_ID=$(aws sts get-caller-identity --output text --query Account)' >> ~/.bashrc


### PR DESCRIPTION
CloudShell 환경에서 kubectl 및 eksctl을 기존 경로인 /usr/local/bin에 설치할 경우,
세션 비활성화로 인한 자동 종료 시 설치된 툴이 사라지는 문제가 있었습니다.

이를 해결하기 위해,  CloudShell의 경우 홈 디렉토리는 초기화 되지 않기 때문에
사용자 홈 디렉토리의 $HOME/.local/bin 경로로 설치하도록 수정하였습니다.
~/.bashrc에 해당 경로가 PATH에 포함되도록 설정하여 문제 없게 조치 완료 했습니ㅏㄷ.