### PR TITLE
feat: serverless deployment for frontends and microservices

### DIFF
--- a/api_setting.sh
+++ b/api_setting.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-customer_directory="/home/cloudshell-user/architect-cloud/2025/s3_customer"
-employee_directory="/home/cloudshell-user/architect-cloud/2025/s3_employee"
+customer_directory="/home/cloudshell-user/architect-cloud/s3_customer"
+employee_directory="/home/cloudshell-user/architect-cloud/s3_employee"
 
 echo "Enter the API URL of customer: "
 read customer_api

--- a/cloudformation/ServerlessApp_CF.yaml
+++ b/cloudformation/ServerlessApp_CF.yaml
@@ -1,6 +1,36 @@
 AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  Serverless coffee-supplier app. Provisions VPC, RDS MySQL, two Lambda
+  microservices (customer / employee) inside the VPC, an HTTP API Gateway,
+  and S3 + CloudFront for the two static frontends.
+
+Parameters:
+  CodeBucket:
+    Type: String
+    Description: S3 bucket holding the packaged Lambda zips (created by utils/package_lambda.sh)
+  CustomerCodeKey:
+    Type: String
+    Default: lambda/customer.zip
+    Description: S3 key of the customer Lambda package
+  EmployeeCodeKey:
+    Type: String
+    Default: lambda/employee.zip
+    Description: S3 key of the employee Lambda package
+  DBUsername:
+    Type: String
+    Default: nodeapp
+  DBPassword:
+    Type: String
+    Default: lab-password
+    NoEcho: true
+  DBName:
+    Type: String
+    Default: COFFEE
 
 Resources:
+  ###########
+  # VPC
+  ###########
   LabVPC:
     Type: AWS::EC2::VPC
     Properties:
@@ -35,10 +65,7 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref LabVPC
-      AvailabilityZone:
-        Fn::Select:
-          - 0
-          - Fn::GetAZs: ""
+      AvailabilityZone: !Select [0, !GetAZs ""]
       CidrBlock: 10.16.10.0/24
       MapPublicIpOnLaunch: true
       Tags:
@@ -49,19 +76,13 @@ Resources:
     Type: AWS::EC2::Subnet
     Properties:
       VpcId: !Ref LabVPC
-      AvailabilityZone:
-        Fn::Select:
-          - 1
-          - Fn::GetAZs: ""
+      AvailabilityZone: !Select [1, !GetAZs ""]
       CidrBlock: 10.16.20.0/24
       MapPublicIpOnLaunch: true
       Tags:
         - Key: Name
           Value: Public Subnet2
 
-  ###########
-  # Public Routing
-  ###########
   PublicRouteTable:
     Type: AWS::EC2::RouteTable
     DependsOn:
@@ -85,24 +106,18 @@ Resources:
 
   PublicSubnetRouteAssociation1:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn:
-      - PublicRouteTable
-      - PublicSubnet1
     Properties:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref PublicSubnet1
 
   PublicSubnetRouteAssociation2:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn:
-      - PublicRouteTable
-      - PublicSubnet2
     Properties:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref PublicSubnet2
 
   ###########
-  # Private Subnets
+  # Private Subnets (Lambda + RDS)
   ###########
   PrivateSubnet1:
     Type: AWS::EC2::Subnet
@@ -110,10 +125,7 @@ Resources:
     Properties:
       VpcId: !Ref LabVPC
       CidrBlock: 10.16.30.0/24
-      AvailabilityZone: !Select
-        - 0
-        - !GetAZs
-          Ref: AWS::Region
+      AvailabilityZone: !Select [0, !GetAZs ""]
       Tags:
         - Key: Name
           Value: Private Subnet 1
@@ -124,17 +136,11 @@ Resources:
     Properties:
       VpcId: !Ref LabVPC
       CidrBlock: 10.16.40.0/24
-      AvailabilityZone: !Select
-        - 1
-        - !GetAZs
-          Ref: AWS::Region
+      AvailabilityZone: !Select [1, !GetAZs ""]
       Tags:
         - Key: Name
           Value: Private Subnet 2
 
-  ###########
-  # Private Routing
-  ###########
   PrivateRouteTable1:
     Type: AWS::EC2::RouteTable
     DependsOn: LabVPC
@@ -155,35 +161,63 @@ Resources:
 
   PrivateRouteTableAssociation1:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn:
-      - PrivateRouteTable1
-      - PrivateSubnet1
     Properties:
       RouteTableId: !Ref PrivateRouteTable1
       SubnetId: !Ref PrivateSubnet1
 
   PrivateRouteTableAssociation2:
     Type: AWS::EC2::SubnetRouteTableAssociation
-    DependsOn:
-      - PrivateRouteTable2
-      - PrivateSubnet2
     Properties:
       RouteTableId: !Ref PrivateRouteTable2
       SubnetId: !Ref PrivateSubnet2
 
   ###########
-  # RDS Database
+  # Security Groups
+  ###########
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Lambda functions ENI security group
+      VpcId: !Ref LabVPC
+      SecurityGroupEgress:
+        - IpProtocol: -1
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: Name
+          Value: LambdaSG
+
+  DBSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: RDS MySQL security group (only Lambda may connect)
+      VpcId: !Ref LabVPC
+      Tags:
+        - Key: Name
+          Value: DBSG
+
+  # Allow MySQL only from the Lambda SG (kept as a separate resource to avoid a circular dependency)
+  DBIngressFromLambda:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref DBSecurityGroup
+      IpProtocol: tcp
+      FromPort: 3306
+      ToPort: 3306
+      SourceSecurityGroupId: !Ref LambdaSecurityGroup
+
+  ###########
+  # RDS Database (private)
   ###########
   DBSubnetGroup:
-    Type: "AWS::RDS::DBSubnetGroup"
+    Type: AWS::RDS::DBSubnetGroup
     Properties:
-      DBSubnetGroupDescription: "Subnet group for RDS"
+      DBSubnetGroupDescription: Private subnet group for RDS
       SubnetIds:
-        - !Ref PublicSubnet1
-        - !Ref PublicSubnet2
+        - !Ref PrivateSubnet1
+        - !Ref PrivateSubnet2
 
   MyDBInstance:
-    Type: "AWS::RDS::DBInstance"
+    Type: AWS::RDS::DBInstance
     DeletionPolicy: Delete
     DependsOn: AttachGateway
     Properties:
@@ -191,34 +225,314 @@ Resources:
       DBInstanceClass: db.t3.micro
       Engine: mysql
       EngineVersion: "8.0.42"
-      MasterUsername: nodeapp
-      MasterUserPassword: lab-password
-      DBName: COFFEE
+      MasterUsername: !Ref DBUsername
+      MasterUserPassword: !Ref DBPassword
+      DBName: !Ref DBName
       DBSubnetGroupName: !Ref DBSubnetGroup
       MultiAZ: false
       AllocatedStorage: 20
       MaxAllocatedStorage: 1000
       StorageType: gp2
       StorageEncrypted: true
-      PubliclyAccessible: true
+      PubliclyAccessible: false
       VPCSecurityGroups:
-        - !Ref MyDBSecurityGroup
+        - !Ref DBSecurityGroup
       Tags:
         - Key: Name
           Value: MyDatabaseInstance
 
-  MyDBSecurityGroup:
-    Type: "AWS::EC2::SecurityGroup"
+  ###########
+  # Lambda
+  ###########
+  LambdaExecutionRole:
+    Type: AWS::IAM::Role
     Properties:
-      GroupDescription: Security group for RDS instance
-      VpcId: !Ref LabVPC
-      SecurityGroupIngress:
-        - IpProtocol: tcp
-          FromPort: 3306
-          ToPort: 3306
-          CidrIp: 0.0.0.0/0
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+
+  CustomerFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: coffee-customer
+      Runtime: nodejs22.x
+      Handler: index.handler
+      Timeout: 30
+      MemorySize: 256
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        S3Bucket: !Ref CodeBucket
+        S3Key: !Ref CustomerCodeKey
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - !Ref PrivateSubnet1
+          - !Ref PrivateSubnet2
+      Environment:
+        Variables:
+          APP_DB_HOST: !GetAtt MyDBInstance.Endpoint.Address
+          APP_DB_USER: !Ref DBUsername
+          APP_DB_PASSWORD: !Ref DBPassword
+          APP_DB_NAME: !Ref DBName
+
+  EmployeeFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: coffee-employee
+      Runtime: nodejs22.x
+      Handler: index.handler
+      Timeout: 30
+      MemorySize: 256
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Code:
+        S3Bucket: !Ref CodeBucket
+        S3Key: !Ref EmployeeCodeKey
+      VpcConfig:
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
+        SubnetIds:
+          - !Ref PrivateSubnet1
+          - !Ref PrivateSubnet2
+      Environment:
+        Variables:
+          APP_DB_HOST: !GetAtt MyDBInstance.Endpoint.Address
+          APP_DB_USER: !Ref DBUsername
+          APP_DB_PASSWORD: !Ref DBPassword
+          APP_DB_NAME: !Ref DBName
+
+  ###########
+  # API Gateway (HTTP API) - customer
+  ###########
+  CustomerApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: coffee-customer-api
+      ProtocolType: HTTP
+      CorsConfiguration:
+        AllowOrigins:
+          - "*"
+        AllowMethods:
+          - "*"
+        AllowHeaders:
+          - "*"
+
+  CustomerIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref CustomerApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt CustomerFunction.Arn
+      PayloadFormatVersion: "2.0"
+
+  CustomerRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref CustomerApi
+      RouteKey: $default
+      Target: !Sub integrations/${CustomerIntegration}
+
+  CustomerStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref CustomerApi
+      StageName: $default
+      AutoDeploy: true
+
+  CustomerInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref CustomerFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${CustomerApi}/*/*
+
+  ###########
+  # API Gateway (HTTP API) - employee
+  ###########
+  EmployeeApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: coffee-employee-api
+      ProtocolType: HTTP
+      CorsConfiguration:
+        AllowOrigins:
+          - "*"
+        AllowMethods:
+          - "*"
+        AllowHeaders:
+          - "*"
+
+  EmployeeIntegration:
+    Type: AWS::ApiGatewayV2::Integration
+    Properties:
+      ApiId: !Ref EmployeeApi
+      IntegrationType: AWS_PROXY
+      IntegrationUri: !GetAtt EmployeeFunction.Arn
+      PayloadFormatVersion: "2.0"
+
+  EmployeeRoute:
+    Type: AWS::ApiGatewayV2::Route
+    Properties:
+      ApiId: !Ref EmployeeApi
+      RouteKey: $default
+      Target: !Sub integrations/${EmployeeIntegration}
+
+  EmployeeStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref EmployeeApi
+      StageName: $default
+      AutoDeploy: true
+
+  EmployeeInvokePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref EmployeeFunction
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${EmployeeApi}/*/*
+
+  ###########
+  # S3 + CloudFront - frontends
+  ###########
+  CustomerBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub coffee-customer-${AWS::AccountId}-${AWS::Region}
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  EmployeeBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub coffee-employee-${AWS::AccountId}-${AWS::Region}
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+
+  FrontendOAC:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: !Sub coffee-frontend-oac-${AWS::StackName}
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
+
+  CustomerDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        DefaultRootObject: home.html
+        Origins:
+          - Id: CustomerS3Origin
+            DomainName: !GetAtt CustomerBucket.RegionalDomainName
+            OriginAccessControlId: !Ref FrontendOAC
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+        DefaultCacheBehavior:
+          TargetOriginId: CustomerS3Origin
+          ViewerProtocolPolicy: redirect-to-https
+          # AWS managed "CachingOptimized" cache policy
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /404.html
+          - ErrorCode: 404
+            ResponseCode: 404
+            ResponsePagePath: /404.html
+
+  EmployeeDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+      DistributionConfig:
+        Enabled: true
+        DefaultRootObject: home.html
+        Origins:
+          - Id: EmployeeS3Origin
+            DomainName: !GetAtt EmployeeBucket.RegionalDomainName
+            OriginAccessControlId: !Ref FrontendOAC
+            S3OriginConfig:
+              OriginAccessIdentity: ""
+        DefaultCacheBehavior:
+          TargetOriginId: EmployeeS3Origin
+          ViewerProtocolPolicy: redirect-to-https
+          CachePolicyId: 658327ea-f89d-4fab-a63d-7e88639e58f6
+        CustomErrorResponses:
+          - ErrorCode: 403
+            ResponseCode: 404
+            ResponsePagePath: /404.html
+          - ErrorCode: 404
+            ResponseCode: 404
+            ResponsePagePath: /404.html
+
+  CustomerBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref CustomerBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowCloudFrontRead
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub ${CustomerBucket.Arn}/*
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${CustomerDistribution}
+
+  EmployeeBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref EmployeeBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowCloudFrontRead
+            Effect: Allow
+            Principal:
+              Service: cloudfront.amazonaws.com
+            Action: s3:GetObject
+            Resource: !Sub ${EmployeeBucket.Arn}/*
+            Condition:
+              StringEquals:
+                AWS:SourceArn: !Sub arn:aws:cloudfront::${AWS::AccountId}:distribution/${EmployeeDistribution}
 
 Outputs:
   DBInstanceEndpoint:
-    Description: "The endpoint address of the RDS instance"
+    Description: RDS MySQL endpoint
     Value: !GetAtt MyDBInstance.Endpoint.Address
+  CustomerApiUrl:
+    Description: Customer API base URL (use as YOUR_API_URL for s3_customer)
+    Value: !GetAtt CustomerApi.ApiEndpoint
+  EmployeeApiUrl:
+    Description: Employee API base URL (use as YOUR_API_URL for s3_employee)
+    Value: !GetAtt EmployeeApi.ApiEndpoint
+  CustomerBucketName:
+    Description: S3 bucket for the customer frontend
+    Value: !Ref CustomerBucket
+  EmployeeBucketName:
+    Description: S3 bucket for the employee frontend
+    Value: !Ref EmployeeBucket
+  CustomerSiteUrl:
+    Description: CloudFront URL for the customer frontend
+    Value: !Sub https://${CustomerDistribution.DomainName}
+  EmployeeSiteUrl:
+    Description: CloudFront URL for the employee frontend
+    Value: !Sub https://${EmployeeDistribution.DomainName}

--- a/utils/deploy_frontend.sh
+++ b/utils/deploy_frontend.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+###############################################################################
+# Inject the API URLs into the static HTML and publish both frontends to their
+# S3 buckets, then invalidate CloudFront.
+#
+# Usage:
+#   ./utils/deploy_frontend.sh <stack-name>
+#
+# Reads the CloudFormation stack outputs (API URLs, bucket names, distribution
+# ids) so it must be run AFTER the stack has been deployed.
+###############################################################################
+set -euo pipefail
+
+STACK="${1:?Usage: deploy_frontend.sh <stack-name>}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+get_output() {
+  aws cloudformation describe-stacks --stack-name "$STACK" \
+    --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" --output text
+}
+
+CUSTOMER_API="$(get_output CustomerApiUrl)"
+EMPLOYEE_API="$(get_output EmployeeApiUrl)"
+CUSTOMER_BUCKET="$(get_output CustomerBucketName)"
+EMPLOYEE_BUCKET="$(get_output EmployeeBucketName)"
+
+echo ">> Customer API : $CUSTOMER_API"
+echo ">> Employee API : $EMPLOYEE_API"
+
+publish() {
+  local src="$1" api="$2" bucket="$3"
+  local work
+  work="$(mktemp -d)"
+  cp -r "$REPO_ROOT/$src/." "$work/"
+  # Replace the API placeholder in every HTML file
+  find "$work" -name '*.html' -exec sed -i.bak "s|YOUR_API_URL|$api|g" {} \;
+  find "$work" -name '*.bak' -delete
+  aws s3 sync "$work" "s3://$bucket" --delete
+  rm -rf "$work"
+  echo ">> Published $src -> s3://$bucket"
+}
+
+publish s3_customer "$CUSTOMER_API" "$CUSTOMER_BUCKET"
+publish s3_employee "$EMPLOYEE_API" "$EMPLOYEE_BUCKET"
+
+# Invalidate CloudFront so the new HTML is served immediately
+for dist in $(aws cloudfront list-distributions \
+  --query "DistributionList.Items[?Origins.Items[?contains(DomainName, '$CUSTOMER_BUCKET') || contains(DomainName, '$EMPLOYEE_BUCKET')]].Id" \
+  --output text); do
+  echo ">> Invalidating CloudFront $dist"
+  aws cloudfront create-invalidation --distribution-id "$dist" --paths "/*" >/dev/null
+done
+
+echo ">> Frontend deploy complete."
+echo "   Customer site: $(get_output CustomerSiteUrl)"
+echo "   Employee site: $(get_output EmployeeSiteUrl)"

--- a/utils/package_lambda.sh
+++ b/utils/package_lambda.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+###############################################################################
+# Build & upload the Lambda packages used by cloudformation/ServerlessApp_CF.yaml
+#
+# Usage:
+#   ./utils/package_lambda.sh <code-bucket-name> [aws-region]
+#
+# Creates <code-bucket> if needed, runs `npm install --omit=dev` for each
+# microservice, zips the code, and uploads to:
+#   s3://<code-bucket>/lambda/customer.zip
+#   s3://<code-bucket>/lambda/employee.zip
+###############################################################################
+set -euo pipefail
+
+CODE_BUCKET="${1:?Usage: package_lambda.sh <code-bucket-name> [region]}"
+REGION="${2:-$(aws configure get region)}"
+REGION="${REGION:-us-east-1}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SRC_DIR="$REPO_ROOT/lambda_code/microservice"
+BUILD_DIR="$(mktemp -d)"
+trap 'rm -rf "$BUILD_DIR"' EXIT
+
+echo ">> Code bucket : $CODE_BUCKET"
+echo ">> Region      : $REGION"
+
+# Create the code bucket if it does not exist
+if ! aws s3api head-bucket --bucket "$CODE_BUCKET" 2>/dev/null; then
+  echo ">> Creating bucket $CODE_BUCKET"
+  if [ "$REGION" = "us-east-1" ]; then
+    aws s3api create-bucket --bucket "$CODE_BUCKET" --region "$REGION"
+  else
+    aws s3api create-bucket --bucket "$CODE_BUCKET" --region "$REGION" \
+      --create-bucket-configuration LocationConstraint="$REGION"
+  fi
+fi
+
+for svc in customer employee; do
+  echo ">> Packaging $svc"
+  pkg_dir="$BUILD_DIR/$svc"
+  cp -r "$SRC_DIR/$svc" "$pkg_dir"
+  ( cd "$pkg_dir" && npm install --omit=dev --no-audit --no-fund )
+  ( cd "$pkg_dir" && zip -qr "$BUILD_DIR/$svc.zip" . -x "*.git*" )
+  aws s3 cp "$BUILD_DIR/$svc.zip" "s3://$CODE_BUCKET/lambda/$svc.zip"
+  echo ">> Uploaded s3://$CODE_BUCKET/lambda/$svc.zip"
+done
+
+echo ">> Done. Deploy with:"
+echo "   aws cloudformation deploy \\"
+echo "     --template-file cloudformation/ServerlessApp_CF.yaml \\"
+echo "     --stack-name coffee-serverless \\"
+echo "     --capabilities CAPABILITY_IAM \\"
+echo "     --parameter-overrides CodeBucket=$CODE_BUCKET"


### PR DESCRIPTION
## 변경 내용

- `ServerlessApp_CF.yaml`을 전체 서버리스 스택으로 확장
  - VPC + 프라이빗 RDS MySQL
  - customer/employee Lambda (VPC 내), HTTP API Gateway + CORS
  - S3 + CloudFront로 두 프론트엔드 배포
- RDS는 Lambda 보안그룹에서만 접근 가능
- `utils/package_lambda.sh`: 람다 코드 빌드/zip/S3 업로드
- `utils/deploy_frontend.sh`: API URL 주입 + S3 배포 + CloudFront 무효화
- 폴더 정리 후 `api_setting.sh` 경로 수정 (2025/ → 루트)

## 검증
- ap-northeast-2에 `coffee-serverless` 스택 배포 완료
- 두 API 200 정상 (suppliers 테이블 자동 생성)
- CloudFront 양 사이트 200, API URL 주입 확인