### PR TITLE
SRE 실습: CloudShell 대응(공유버킷) + GitHub Actions 산출물 발행 CI

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -1,0 +1,68 @@
+name: Publish Lab Artifacts
+
+# SRE 실습 공유 산출물(coffee Lambda 코드 / injector / 의존성 레이어)을 빌드해
+# 공유 버킷(samsung-cloud-architect)에 발행합니다. publish_artifacts.sh 를 그대로 실행.
+# org secrets: HYU_DDPS_AWS_ID / HYU_DDPS_AWS_SECRET
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - master
+      - main
+    paths:
+      - 'agent_sre/requirements.txt'
+      - 'agent_sre/faults/injector_lambda/**'
+      - 'agent_sre/infra/publish_artifacts.sh'
+      - 'lambda_code/microservice/**'
+      - '.github/workflows/publish-artifacts.yml'
+
+permissions:
+  contents: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  SHARED_BUCKET: samsung-cloud-architect
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Setup Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.HYU_DDPS_AWS_ID }}
+          aws-secret-access-key: ${{ secrets.HYU_DDPS_AWS_SECRET }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Build & publish artifacts
+        working-directory: agent_sre
+        run: ./infra/publish_artifacts.sh
+
+      - name: Verify artifacts in S3
+        run: |
+          set -euo pipefail
+          fail=0
+          for key in coffee/customer.zip coffee/employee.zip copilot/injector.zip copilot/layer.zip; do
+            size=$(aws s3api head-object --bucket "$SHARED_BUCKET" --key "$key" \
+              --region "$AWS_REGION" --query 'ContentLength' --output text 2>/dev/null || echo "MISSING")
+            if [ "$size" = "MISSING" ] || [ "$size" = "0" ]; then
+              echo "::error::$key 누락 또는 0바이트 ($size)"; fail=1
+            else
+              echo "OK  $key  ($size bytes)"
+            fi
+          done
+          exit $fail

--- a/agent_sre/README.md
+++ b/agent_sre/README.md
@@ -29,9 +29,10 @@ danluu 회고 모음을 지식베이스로 삼아, **하나의 AWS Strands 에�
 
 | 구분 | 누가 | 방법 |
 |------|------|------|
+| 공유 산출물(injector.zip·layer.zip) | 강사 (전역 1회) | `infra/publish_artifacts.sh` |
 | 공유 채팅 웹 | 강사 (전역 1회) | `web-chat/deploy_chat.sh` |
 | coffee-serverless (대상+RDS) | 수강생 (각자) | `../cloudformation/ServerlessApp_CF.yaml` |
-| LabBase: 장애주입·IAM 역할·세션버킷·레이어 | 수강생 (각자, CF 1회) | `infra/deploy_labbase.sh` |
+| LabBase: 장애주입·IAM 역할·세션버킷·레이어 | 수강생 (각자, CF 1회) | `infra/deploy_labbase.sh` (빌드 없이 cp) |
 | **S3 Vectors · Knowledge Base · 적재** | **수강생 (직접)** | 핵심 실습 |
 | **에이전트 Lambda 생성·편집** | **수강생 (직접, 콘솔)** | 핵심 실습 |
 | 장애 주입 | 수강생 (각자) | `faults/inject.sh` (자기 RDS) |
@@ -48,7 +49,8 @@ agent_sre/
 │   └── m4_knowledge_base.py m5_aws_docs.py
 ├── infra/
 │   ├── LabBase_CF.yaml      injector·IAM역할·세션버킷·레이어 (수강생 1회)
-│   ├── deploy_labbase.sh    위 배포 + 코드/레이어 빌드·업로드
+│   ├── publish_artifacts.sh injector.zip·layer.zip 빌드→공유버킷 (강사 1회)
+│   ├── deploy_labbase.sh    공유버킷→내버킷 cp + CF 배포 (수강생, 빌드 없음)
 │   └── build_function_zip.sh  function.zip(lambda_src) 생성
 ├── kb/                  setup_s3vectors.sh, ingest_danluu.py, data/(회고 20건)
 ├── faults/              inject.sh / restore.sh / injector_lambda/

--- a/agent_sre/README.md
+++ b/agent_sre/README.md
@@ -29,10 +29,11 @@ danluu 회고 모음을 지식베이스로 삼아, **하나의 AWS Strands 에�
 
 | 구분 | 누가 | 방법 |
 |------|------|------|
-| 공유 산출물(injector.zip·layer.zip) | 강사 (전역 1회) | `infra/publish_artifacts.sh` |
+| 공유 산출물(injector.zip·layer.zip) | 강사 (전역 1회) | `infra/publish_artifacts.sh` → `samsung-cloud-architect` |
 | 공유 채팅 웹 | 강사 (전역 1회) | `web-chat/deploy_chat.sh` |
 | coffee-serverless (대상+RDS) | 수강생 (각자) | `../cloudformation/ServerlessApp_CF.yaml` |
-| LabBase: 장애주입·IAM 역할·세션버킷·레이어 | 수강생 (각자, CF 1회) | `infra/deploy_labbase.sh` (빌드 없이 cp) |
+| LabBase: 장애주입·IAM 역할·세션버킷 | 수강생 (각자, CF 1회) | `infra/deploy_labbase.sh` |
+| **의존성 레이어** | **수강생 (직접, 콘솔)** | 공유 버킷 layer.zip S3 링크로 생성 |
 | **S3 Vectors · Knowledge Base · 적재** | **수강생 (직접)** | 핵심 실습 |
 | **에이전트 Lambda 생성·편집** | **수강생 (직접, 콘솔)** | 핵심 실습 |
 | 장애 주입 | 수강생 (각자) | `faults/inject.sh` (자기 RDS) |
@@ -48,9 +49,9 @@ agent_sre/
 │   ├── m1_prompt.py m1_model.py m2_tools.py m3_memory.py
 │   └── m4_knowledge_base.py m5_aws_docs.py
 ├── infra/
-│   ├── LabBase_CF.yaml      injector·IAM역할·세션버킷·레이어 (수강생 1회)
+│   ├── LabBase_CF.yaml      injector(공유버킷 참조)·IAM역할·세션버킷 (수강생 1회)
 │   ├── publish_artifacts.sh injector.zip·layer.zip 빌드→공유버킷 (강사 1회)
-│   ├── deploy_labbase.sh    공유버킷→내버킷 cp + CF 배포 (수강생, 빌드 없음)
+│   ├── deploy_labbase.sh    CF 배포 (수강생, 빌드/복사 없음)
 │   └── build_function_zip.sh  function.zip(lambda_src) 생성
 ├── kb/                  setup_s3vectors.sh, ingest_danluu.py, data/(회고 20건)
 ├── faults/              inject.sh / restore.sh / injector_lambda/

--- a/agent_sre/docs/INSTRUCTOR_SETUP.md
+++ b/agent_sre/docs/INSTRUCTOR_SETUP.md
@@ -17,9 +17,9 @@ cd architect-cloud/agent_sre
 # 출력된 SHARED_BUCKET 이름을 수강생에게 공유
 ```
 
-> 기본 공유 버킷명은 `copilot-artifacts-<강사계정>-apne2` 입니다. 수강생용
-> `deploy_labbase.sh` 의 기본값(`copilot-artifacts-786382940258-apne2`)과 다르면,
-> 수강생에게 `SHARED_BUCKET=<버킷명>` 을 앞에 붙여 실행하도록 안내하세요.
+> 기본 공유 버킷명은 `samsung-cloud-architect` 입니다(수강생용 기본값과 동일).
+> 다른 버킷을 쓰려면 `SHARED_BUCKET=<버킷명> ./infra/publish_artifacts.sh` 로 발행하고,
+> 수강생에게도 같은 `SHARED_BUCKET` 을 앞에 붙여 실행하도록 안내하세요.
 > 산출물(Strands/awslabs 등)을 갱신했을 때만 다시 실행하면 됩니다.
 
 ## 1. 공유 채팅 웹 배포 (전역 1회)
@@ -52,10 +52,11 @@ cd architect-cloud/agent_sre
 
 | 구분 | 누가 | 무엇 |
 |------|------|------|
-| **공유 산출물(injector.zip·layer.zip) 빌드·발행** | 강사(1회) | `infra/publish_artifacts.sh` → 퍼블릭 버킷 |
+| **공유 산출물(injector.zip·layer.zip) 빌드·발행** | 강사(1회) | `infra/publish_artifacts.sh` → `samsung-cloud-architect` |
 | 공유 채팅 웹 | 강사(1회) | S3+CloudFront SPA (`web-chat/`) |
 | coffee-serverless | 수강생(각자) | 대상 서비스 + RDS |
-| LabBase (injector·IAM 역할·세션버킷·레이어) | 수강생(각자, CF) | `infra/deploy_labbase.sh` (빌드 없이 cp) |
+| LabBase (injector·IAM 역할·세션버킷) | 수강생(각자, CF) | `infra/deploy_labbase.sh` (injector 는 공유 버킷 직접 참조) |
+| **의존성 레이어** | **수강생(직접, 콘솔)** | 공유 버킷 layer.zip S3 링크로 레이어 생성 |
 | **S3 Vectors / Knowledge Base / 적재** | **수강생(직접)** | 핵심 실습 |
 | **에이전트 Lambda 생성·편집** | **수강생(직접, 콘솔)** | 핵심 실습 |
 | 장애 주입 | 수강생(각자) | `faults/inject.sh` (자기 RDS 대상) |

--- a/agent_sre/docs/INSTRUCTOR_SETUP.md
+++ b/agent_sre/docs/INSTRUCTOR_SETUP.md
@@ -28,6 +28,16 @@ cd architect-cloud/agent_sre
 > 수강생 배포 명령에도 같은 버킷명을 `CodeBucket=` / `SHARED_BUCKET=` 로 전달하도록 안내.
 > 산출물(coffee 코드 / Strands 등)을 갱신했을 때만 다시 실행하면 됩니다.
 
+### CI 자동 발행 (GitHub Actions)
+
+위 스크립트는 `.github/workflows/publish-artifacts.yml` 로 자동화돼 있어, 보통은
+손으로 실행할 필요가 없습니다. coffee 코드·injector·`requirements.txt`·스크립트가
+바뀌어 **master 에 머지**되면 자동으로 빌드·발행되고, 수동 실행도 가능합니다
+(Actions 탭 → *Publish Lab Artifacts* → **Run workflow**).
+자격증명은 org secrets `HYU_DDPS_AWS_ID` / `HYU_DDPS_AWS_SECRET` 를 사용합니다
+(리전 `ap-northeast-2`, 버킷 `samsung-cloud-architect`). 마지막 스텝이 4개 산출물의
+S3 존재·크기를 검증합니다.
+
 ## 1. 공유 채팅 웹 배포 (전역 1회)
 
 정적 채팅 SPA를 한 벌만 배포하고, 그 URL을 모든 수강생에게 공유합니다. 수강생은

--- a/agent_sre/docs/INSTRUCTOR_SETUP.md
+++ b/agent_sre/docs/INSTRUCTOR_SETUP.md
@@ -2,6 +2,26 @@
 
 수강생 실습 전에 강사가 한 번 해두는 것들입니다.
 
+## 0. 공유 산출물 발행 (전역 1회) — `publish_artifacts.sh`
+
+CloudShell은 사양·용량이 빠듯해서 수강생이 직접 라이브러리 레이어(pip manylinux,
+약 80MB)나 injector(npm)를 빌드하면 부담이 큽니다. 그래서 **강사가 한 번만 빌드**해
+퍼블릭 읽기 공유 버킷에 올려두고, 수강생은 빌드 없이 `aws s3 cp` 로만 가져갑니다.
+
+**CloudShell**(서울 리전)에서:
+
+```sh
+git clone https://github.com/ddps-lab/architect-cloud.git
+cd architect-cloud/agent_sre
+./infra/publish_artifacts.sh         # injector.zip + layer.zip 빌드 → 공유 버킷 업로드
+# 출력된 SHARED_BUCKET 이름을 수강생에게 공유
+```
+
+> 기본 공유 버킷명은 `copilot-artifacts-<강사계정>-apne2` 입니다. 수강생용
+> `deploy_labbase.sh` 의 기본값(`copilot-artifacts-786382940258-apne2`)과 다르면,
+> 수강생에게 `SHARED_BUCKET=<버킷명>` 을 앞에 붙여 실행하도록 안내하세요.
+> 산출물(Strands/awslabs 등)을 갱신했을 때만 다시 실행하면 됩니다.
+
 ## 1. 공유 채팅 웹 배포 (전역 1회)
 
 정적 채팅 SPA를 한 벌만 배포하고, 그 URL을 모든 수강생에게 공유합니다. 수강생은
@@ -22,6 +42,7 @@ cd architect-cloud/agent_sre
 
 - 이 저장소(`agent_sre/`)
 - 공유 채팅 사이트 URL (위 1번 출력)
+- **공유 산출물 버킷명** `SHARED_BUCKET` (위 0번 출력) — 기본값과 다를 때만
 - 각자 **자기 AWS 환경에 `coffee-serverless` 스택이 배포돼 있어야 함**
   (대상 마이크로서비스 + RDS). → `../cloudformation/ServerlessApp_CF.yaml`
 - Bedrock 모델 액세스 활성화(ap-northeast-2): 사용할 모델 + Titan Text Embeddings v2
@@ -31,9 +52,10 @@ cd architect-cloud/agent_sre
 
 | 구분 | 누가 | 무엇 |
 |------|------|------|
+| **공유 산출물(injector.zip·layer.zip) 빌드·발행** | 강사(1회) | `infra/publish_artifacts.sh` → 퍼블릭 버킷 |
 | 공유 채팅 웹 | 강사(1회) | S3+CloudFront SPA (`web-chat/`) |
 | coffee-serverless | 수강생(각자) | 대상 서비스 + RDS |
-| LabBase (injector·IAM 역할·세션버킷·레이어) | 수강생(각자, CF) | `infra/deploy_labbase.sh` |
+| LabBase (injector·IAM 역할·세션버킷·레이어) | 수강생(각자, CF) | `infra/deploy_labbase.sh` (빌드 없이 cp) |
 | **S3 Vectors / Knowledge Base / 적재** | **수강생(직접)** | 핵심 실습 |
 | **에이전트 Lambda 생성·편집** | **수강생(직접, 콘솔)** | 핵심 실습 |
 | 장애 주입 | 수강생(각자) | `faults/inject.sh` (자기 RDS 대상) |

--- a/agent_sre/docs/INSTRUCTOR_SETUP.md
+++ b/agent_sre/docs/INSTRUCTOR_SETUP.md
@@ -4,23 +4,29 @@
 
 ## 0. 공유 산출물 발행 (전역 1회) — `publish_artifacts.sh`
 
-CloudShell은 사양·용량이 빠듯해서 수강생이 직접 라이브러리 레이어(pip manylinux,
-약 80MB)나 injector(npm)를 빌드하면 부담이 큽니다. 그래서 **강사가 한 번만 빌드**해
-퍼블릭 읽기 공유 버킷에 올려두고, 수강생은 빌드 없이 `aws s3 cp` 로만 가져갑니다.
+CloudShell은 사양·용량이 빠듯해서 수강생이 직접 빌드(npm / pip manylinux 약 80MB)하면
+부담이 큽니다. 그래서 **강사가 한 번만 빌드**해 퍼블릭 읽기 공유 버킷
+(`samsung-cloud-architect`)에 올려둡니다. 수강생은 빌드 없이 그 버킷을 참조만 합니다.
 
 **CloudShell**(서울 리전)에서:
 
 ```sh
 git clone https://github.com/ddps-lab/architect-cloud.git
 cd architect-cloud/agent_sre
-./infra/publish_artifacts.sh         # injector.zip + layer.zip 빌드 → 공유 버킷 업로드
+./infra/publish_artifacts.sh         # coffee zip + injector.zip + layer.zip 빌드 → 공유 버킷
 # 출력된 SHARED_BUCKET 이름을 수강생에게 공유
 ```
 
+올라가는 산출물:
+- `coffee/customer.zip`, `coffee/employee.zip` — `ServerlessApp_CF` Lambda 코드
+  (수강생은 코드 버킷을 따로 안 만들고 이 버킷에서 바로 끌어옴)
+- `copilot/injector.zip` — LabBase 장애 주입기 코드
+- `copilot/layer.zip` — 수강생이 콘솔에서 의존성 레이어로 생성
+
 > 기본 공유 버킷명은 `samsung-cloud-architect` 입니다(수강생용 기본값과 동일).
 > 다른 버킷을 쓰려면 `SHARED_BUCKET=<버킷명> ./infra/publish_artifacts.sh` 로 발행하고,
-> 수강생에게도 같은 `SHARED_BUCKET` 을 앞에 붙여 실행하도록 안내하세요.
-> 산출물(Strands/awslabs 등)을 갱신했을 때만 다시 실행하면 됩니다.
+> 수강생 배포 명령에도 같은 버킷명을 `CodeBucket=` / `SHARED_BUCKET=` 로 전달하도록 안내.
+> 산출물(coffee 코드 / Strands 등)을 갱신했을 때만 다시 실행하면 됩니다.
 
 ## 1. 공유 채팅 웹 배포 (전역 1회)
 

--- a/agent_sre/docs/STUDENT_GUIDE.md
+++ b/agent_sre/docs/STUDENT_GUIDE.md
@@ -36,9 +36,9 @@ cd architect-cloud/agent_sre
 
 ## 1. 부품 배포 (CF, 1회) — `deploy_labbase.sh`
 
-장애 주입 Lambda(내 RDS 대상) + 에이전트 IAM 역할 + 세션 버킷 + 의존성 레이어를
-한 번에 만듭니다. 무거운 산출물(injector.zip·layer.zip)은 강사가 미리 빌드해
-공유 버킷에 올려뒀으므로, 이 스크립트는 **빌드 없이 그것을 내 버킷으로 복사만** 합니다
+장애 주입 Lambda(내 RDS 대상) + 에이전트 IAM 역할 + 세션 버킷을 한 번에 만듭니다.
+장애 주입 코드(injector.zip)는 강사가 미리 올려둔 공유 버킷
+(`samsung-cloud-architect`)에서 CF가 **직접 참조**하므로, 빌드도 복사도 없습니다
 (CloudShell 부담 없음).
 
 ```sh
@@ -51,10 +51,25 @@ cd agent_sre
 
 끝나면 출력 표에서 다음을 메모하세요:
 - `AgentRoleArn` — 에이전트 Lambda 실행 역할
-- `DepsLayerArn` — 의존성 레이어
 - `LwaLayerArn` — Lambda Web Adapter 레이어
 - `SessionBucketName` — env `SESSION_BUCKET`
 - `InjectorFunctionName` — env `INJECTOR_FN` (보통 `coffee-fault-injector`)
+
+또한 스크립트 마지막에 안내되는 **layer.zip 의 S3 링크 URL** 을 메모합니다(다음 단계).
+
+---
+
+## 1-B. 의존성 레이어 만들기 (콘솔, 직접)
+
+라이브러리(Strands/fastapi/uvicorn/mcp/awslabs...)는 강사가 미리 빌드해 공유
+버킷에 올려뒀습니다. 여러분은 그 S3 링크로 **레이어만 직접 생성**합니다(빌드 없음).
+
+1. **Lambda 콘솔 → Layers → Create layer**
+2. Name: `copilot-deps`
+3. **Upload a file from Amazon S3** 선택 → S3 링크 URL 붙여넣기:
+   `https://samsung-cloud-architect.s3.ap-northeast-2.amazonaws.com/copilot/layer.zip`
+4. Compatible runtimes: **Python 3.12**
+5. Create → 만들어진 **레이어 버전 ARN(`DepsLayerArn`)** 을 메모(4-4에서 사용)
 
 ---
 
@@ -112,8 +127,8 @@ CloudShell에서 만든 `function.zip` 을 콘솔에 올리려면 내 PC로 내�
 - **Timeout**: 5 min, **Memory**: 1024 MB
 
 ### 4-4. 레이어 추가 (Code 탭 → Layers → Add a layer → Specify an ARN)
-- `LwaLayerArn` (Lambda Web Adapter)
-- `DepsLayerArn` (의존성)
+- `LwaLayerArn` (Lambda Web Adapter, 1번 출력)
+- `DepsLayerArn` (의존성, 1-B에서 직접 만든 레이어)
 
 ### 4-5. 환경변수 (Configuration → Environment variables)
 

--- a/agent_sre/docs/STUDENT_GUIDE.md
+++ b/agent_sre/docs/STUDENT_GUIDE.md
@@ -32,6 +32,16 @@ cd architect-cloud/agent_sre
 > 없습니다. 홈 디렉터리는 세션이 끊겨도 유지되지만, 20분 이상 미사용 시 세션이
 >재시작될 수 있습니다(그때는 다시 `cd architect-cloud/agent_sre`).
 
+> **아직 `coffee-serverless` 가 없다면** 코드 버킷을 만들 필요 없이 바로 배포합니다.
+> Lambda 코드(`coffee/customer.zip`·`coffee/employee.zip`)는 강사 공유 버킷
+> (`samsung-cloud-architect`)에서 끌어옵니다(빌드 불필요):
+> ```sh
+> aws cloudformation deploy \
+>   --template-file ../cloudformation/ServerlessApp_CF.yaml \
+>   --stack-name coffee-serverless --capabilities CAPABILITY_IAM
+> ```
+> (강사 공유 버킷명이 다르면 `--parameter-overrides CodeBucket=<버킷명>` 추가)
+
 ---
 
 ## 1. 부품 배포 (CF, 1회) — `deploy_labbase.sh`
@@ -146,9 +156,9 @@ CloudShell에서 만든 `function.zip` 을 콘솔에 올리려면 내 PC로 내�
 | `COFFEE_EMPLOYEE_API` | coffee-serverless 출력 `EmployeeApiUrl` |
 | `COFFEE_CUSTOMER_FN` | `coffee-customer` |
 | `COFFEE_EMPLOYEE_FN` | `coffee-employee` |
-| `CODE_BUCKET` | `coffee-lambda-code-<account>-apne2` |
-| `CUSTOMER_CLEAN_KEY` | `lambda/customer.zip` |
-| `EMPLOYEE_CLEAN_KEY` | `lambda/employee.zip` |
+| `CODE_BUCKET` | `samsung-cloud-architect` (공유 버킷) |
+| `CUSTOMER_CLEAN_KEY` | `coffee/customer.zip` |
+| `EMPLOYEE_CLEAN_KEY` | `coffee/employee.zip` |
 
 > coffee API 주소: `aws cloudformation describe-stacks --stack-name coffee-serverless
 > --query "Stacks[0].Outputs"` 에서 확인.

--- a/agent_sre/docs/STUDENT_GUIDE.md
+++ b/agent_sre/docs/STUDENT_GUIDE.md
@@ -37,12 +37,17 @@ cd architect-cloud/agent_sre
 ## 1. 부품 배포 (CF, 1회) — `deploy_labbase.sh`
 
 장애 주입 Lambda(내 RDS 대상) + 에이전트 IAM 역할 + 세션 버킷 + 의존성 레이어를
-한 번에 만듭니다.
+한 번에 만듭니다. 무거운 산출물(injector.zip·layer.zip)은 강사가 미리 빌드해
+공유 버킷에 올려뒀으므로, 이 스크립트는 **빌드 없이 그것을 내 버킷으로 복사만** 합니다
+(CloudShell 부담 없음).
 
 ```sh
 cd agent_sre
 ./infra/deploy_labbase.sh
 ```
+
+> 강사가 알려준 공유 버킷명이 기본값과 다르면 앞에 붙여 실행하세요:
+> `SHARED_BUCKET=<강사가 알려준 버킷> ./infra/deploy_labbase.sh`
 
 끝나면 출력 표에서 다음을 메모하세요:
 - `AgentRoleArn` — 에이전트 Lambda 실행 역할

--- a/agent_sre/infra/LabBase_CF.yaml
+++ b/agent_sre/infra/LabBase_CF.yaml
@@ -2,9 +2,11 @@ AWSTemplateFormatVersion: "2010-09-09"
 Description: >
   SRE Incident Copilot — LAB BASE (미리 배포되는 부품).
   각 수강생이 자신의 환경에 1회 배포합니다. 장애 주입 Lambda(자기 RDS 대상),
-  에이전트가 붙일 IAM 역할, 세션(기억) 버킷, 의존성 레이어를 만듭니다.
-  ※ 핵심 실습(S3 Vectors / Knowledge Base / 에이전트 Lambda)은 학생이 직접 콘솔에서
-  만듭니다 — 이 템플릿에 포함되지 않습니다. web-chat 도 별도(전역 1회)입니다.
+  에이전트가 붙일 IAM 역할, 세션(기억) 버킷을 만듭니다.
+  ※ 의존성 레이어는 학생이 콘솔에서 공유 버킷(samsung-cloud-architect) layer.zip
+  S3 링크로 직접 생성합니다. 핵심 실습(S3 Vectors / Knowledge Base / 에이전트 Lambda)
+  도 학생이 직접 콘솔에서 만듭니다 — 이 템플릿에 포함되지 않습니다.
+  web-chat 도 별도(전역 1회)입니다.
 
 Parameters:
   PrivateSubnetIds:
@@ -27,28 +29,16 @@ Parameters:
     Default: COFFEE
   CodeBucket:
     Type: String
-    Description: injector.zip / layer.zip / 정규 coffee 빌드(customer.zip/employee.zip)가 있는 버킷
+    Description: 정규 coffee 빌드(customer.zip/employee.zip)가 있는 버킷 (재배포 도구용)
+  ArtifactsBucket:
+    Type: String
+    Default: samsung-cloud-architect
+    Description: 공유 산출물(injector.zip / layer.zip)이 있는 루트 계정 버킷
   InjectorCodeKey:
     Type: String
     Default: copilot/injector.zip
-  LayerCodeKey:
-    Type: String
-    Default: copilot/layer.zip
 
 Resources:
-  ###########
-  # 의존성 레이어 (Strands/fastapi/uvicorn/mcp/awslabs ...)
-  ###########
-  DepsLayer:
-    Type: AWS::Lambda::LayerVersion
-    Properties:
-      LayerName: copilot-deps
-      CompatibleRuntimes:
-        - python3.12
-      Content:
-        S3Bucket: !Ref CodeBucket
-        S3Key: !Ref LayerCodeKey
-
   ###########
   # 세션(기억) 버킷 — 에이전트 S3SessionManager 용
   ###########
@@ -88,7 +78,7 @@ Resources:
       MemorySize: 256
       Role: !GetAtt InjectorRole.Arn
       Code:
-        S3Bucket: !Ref CodeBucket
+        S3Bucket: !Ref ArtifactsBucket
         S3Key: !Ref InjectorCodeKey
       VpcConfig:
         SecurityGroupIds:
@@ -166,9 +156,6 @@ Outputs:
   AgentRoleArn:
     Description: 학생 에이전트 Lambda 에 붙일 실행 역할
     Value: !GetAtt AgentRole.Arn
-  DepsLayerArn:
-    Description: 에이전트 Lambda 에 추가할 의존성 레이어
-    Value: !Ref DepsLayer
   SessionBucketName:
     Description: 에이전트 env SESSION_BUCKET 값
     Value: !Ref SessionBucket

--- a/agent_sre/infra/deploy_labbase.sh
+++ b/agent_sre/infra/deploy_labbase.sh
@@ -17,13 +17,12 @@
 set -euo pipefail
 
 REGION="${1:-${AWS_REGION:-ap-northeast-2}}"
-ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COPILOT="$(cd "$HERE/.." && pwd)"
 COFFEE_STACK="coffee-serverless"
 STACK="copilot-labbase"
-CODE_BUCKET="coffee-lambda-code-${ACCOUNT}-apne2"          # 내 정규 coffee 빌드 버킷 (재배포 도구용)
 SHARED_BUCKET="${SHARED_BUCKET:-samsung-cloud-architect}"  # 강사 공유 산출물 버킷
+                                                           # (injector·layer·깨끗한 coffee zip)
 
 echo ">> [1/3] coffee-serverless 배선 읽기"
 out() { aws cloudformation describe-stacks --stack-name "$COFFEE_STACK" --region "$REGION" \
@@ -42,7 +41,7 @@ aws cloudformation deploy \
     "PrivateSubnetIds=${SUBNET1},${SUBNET2}" \
     "LambdaSecurityGroupId=${LAMBDA_SG}" \
     "DbHost=${DB_HOST}" \
-    "CodeBucket=${CODE_BUCKET}" \
+    "CodeBucket=${SHARED_BUCKET}" \
     "ArtifactsBucket=${SHARED_BUCKET}"
 
 echo ">> [3/3] 완료. 아래 출력값을 에이전트 Lambda 만들 때 사용하세요:"

--- a/agent_sre/infra/deploy_labbase.sh
+++ b/agent_sre/infra/deploy_labbase.sh
@@ -4,8 +4,13 @@
 # injector Lambda(자기 RDS 대상) + 에이전트 IAM 역할 + 세션 버킷 + 의존성 레이어를
 # 만듭니다. 핵심 실습(S3 Vectors / KB / 에이전트 Lambda)은 이후 콘솔에서 직접.
 #
+# ※ CloudShell 사양/용량 부담을 피하려고 무거운 산출물(injector.zip / layer.zip)은
+#   강사가 미리 빌드해 공유 버킷에 올려둡니다. 이 스크립트는 빌드 없이 그것을
+#   내 CODE_BUCKET 으로 `aws s3 cp` 만 합니다.
+#
 # 사전: coffee-serverless 스택이 같은 환경에 배포돼 있어야 합니다.
 # 사용: ./infra/deploy_labbase.sh [region]
+# (강사 안내가 다르면) SHARED_BUCKET=<강사가 알려준 버킷> ./infra/deploy_labbase.sh
 ###############################################################################
 set -euo pipefail
 
@@ -15,23 +20,14 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COPILOT="$(cd "$HERE/.." && pwd)"
 COFFEE_STACK="coffee-serverless"
 STACK="copilot-labbase"
-CODE_BUCKET="coffee-lambda-code-${ACCOUNT}-apne2"   # 정규 coffee 빌드가 있는 버킷 재사용
+CODE_BUCKET="coffee-lambda-code-${ACCOUNT}-apne2"        # 내 정규 coffee 빌드 버킷 재사용
+SHARED_BUCKET="${SHARED_BUCKET:-copilot-artifacts-786382940258-apne2}"  # 강사 공유 버킷
 
-echo ">> [1/4] injector Lambda 패키징 (Node)"
-INJ="$(mktemp -d)"
-cp -r "$COPILOT/faults/injector_lambda/." "$INJ/"
-( cd "$INJ" && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1 && zip -qr /tmp/injector.zip . )
-aws s3 cp /tmp/injector.zip "s3://$CODE_BUCKET/copilot/injector.zip" --region "$REGION"
+echo ">> [1/4] 공유 산출물 가져오기 (빌드 없음, cp 만): $SHARED_BUCKET"
+aws s3 cp "s3://$SHARED_BUCKET/copilot/injector.zip" "s3://$CODE_BUCKET/copilot/injector.zip" --region "$REGION"
+aws s3 cp "s3://$SHARED_BUCKET/copilot/layer.zip"    "s3://$CODE_BUCKET/copilot/layer.zip"    --region "$REGION"
 
-echo ">> [2/4] 의존성 레이어 빌드 (Python, linux wheels)"
-LYR="$(mktemp -d)"; mkdir -p "$LYR/python"
-python3 -m pip install -r "$COPILOT/requirements.txt" -t "$LYR/python" \
-  --platform manylinux2014_x86_64 --python-version 3.12 --only-binary=:all: --quiet
-rm -rf "$LYR/python"/boto3 "$LYR/python"/botocore "$LYR/python"/boto3-* "$LYR/python"/botocore-*
-( cd "$LYR" && zip -qr /tmp/layer.zip . -x "*.pyc" "*/__pycache__/*" )
-aws s3 cp /tmp/layer.zip "s3://$CODE_BUCKET/copilot/layer.zip" --region "$REGION"
-
-echo ">> [3/4] coffee-serverless 배선 읽기"
+echo ">> [2/4] coffee-serverless 배선 읽기"
 out() { aws cloudformation describe-stacks --stack-name "$COFFEE_STACK" --region "$REGION" \
   --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" --output text; }
 res() { aws cloudformation describe-stack-resources --stack-name "$COFFEE_STACK" --region "$REGION" \
@@ -40,7 +36,7 @@ DB_HOST="$(out DBInstanceEndpoint)"
 SUBNET1="$(res PrivateSubnet1)"; SUBNET2="$(res PrivateSubnet2)"
 LAMBDA_SG="$(res LambdaSecurityGroup)"
 
-echo ">> [4/4] $STACK 배포"
+echo ">> [3/4] $STACK 배포"
 aws cloudformation deploy \
   --template-file "$COPILOT/infra/LabBase_CF.yaml" \
   --stack-name "$STACK" --capabilities CAPABILITY_NAMED_IAM --region "$REGION" \
@@ -50,12 +46,11 @@ aws cloudformation deploy \
     "DbHost=${DB_HOST}" \
     "CodeBucket=${CODE_BUCKET}"
 
-# 같은 S3 키로 다시 올려도 CFN이 코드를 안 끌어오므로 injector는 강제 갱신.
+echo ">> [4/4] injector 코드 강제 갱신 (같은 S3 키면 CFN이 안 끌어오므로)"
 aws lambda update-function-code --function-name coffee-fault-injector --region "$REGION" \
   --s3-bucket "$CODE_BUCKET" --s3-key copilot/injector.zip --query LastModified --output text >/dev/null 2>&1 || true
 aws lambda wait function-updated --function-name coffee-fault-injector --region "$REGION" 2>/dev/null || true
 
-rm -rf "$INJ" "$LYR" /tmp/injector.zip /tmp/layer.zip
 echo ">> 완료. 아래 출력값을 에이전트 Lambda 만들 때 사용하세요:"
 aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
   --query "Stacks[0].Outputs" --output table

--- a/agent_sre/infra/deploy_labbase.sh
+++ b/agent_sre/infra/deploy_labbase.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 ###############################################################################
 # LAB BASE 배포 (각 수강생이 자기 환경에 1회 실행).
-# injector Lambda(자기 RDS 대상) + 에이전트 IAM 역할 + 세션 버킷 + 의존성 레이어를
-# 만듭니다. 핵심 실습(S3 Vectors / KB / 에이전트 Lambda)은 이후 콘솔에서 직접.
+# 장애 주입 Lambda(자기 RDS 대상) + 에이전트 IAM 역할 + 세션 버킷을 만듭니다.
+# 핵심 실습(S3 Vectors / KB / 에이전트 Lambda)과 의존성 레이어는 이후 콘솔에서 직접.
 #
-# ※ CloudShell 사양/용량 부담을 피하려고 무거운 산출물(injector.zip / layer.zip)은
-#   강사가 미리 빌드해 공유 버킷에 올려둡니다. 이 스크립트는 빌드 없이 그것을
-#   내 CODE_BUCKET 으로 `aws s3 cp` 만 합니다.
+# ※ CloudShell 부담을 피하려고 빌드는 하지 않습니다. 무거운 산출물
+#   (injector.zip / layer.zip)은 강사가 미리 빌드해 공유 버킷
+#   (samsung-cloud-architect)에 올려둡니다.
+#     - injector.zip : 이 CF 가 공유 버킷에서 직접 참조해 배포
+#     - layer.zip    : 학생이 콘솔에서 그 S3 링크로 레이어를 직접 생성 (아래 안내)
 #
 # 사전: coffee-serverless 스택이 같은 환경에 배포돼 있어야 합니다.
 # 사용: ./infra/deploy_labbase.sh [region]
@@ -20,14 +22,10 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COPILOT="$(cd "$HERE/.." && pwd)"
 COFFEE_STACK="coffee-serverless"
 STACK="copilot-labbase"
-CODE_BUCKET="coffee-lambda-code-${ACCOUNT}-apne2"        # 내 정규 coffee 빌드 버킷 재사용
-SHARED_BUCKET="${SHARED_BUCKET:-copilot-artifacts-786382940258-apne2}"  # 강사 공유 버킷
+CODE_BUCKET="coffee-lambda-code-${ACCOUNT}-apne2"          # 내 정규 coffee 빌드 버킷 (재배포 도구용)
+SHARED_BUCKET="${SHARED_BUCKET:-samsung-cloud-architect}"  # 강사 공유 산출물 버킷
 
-echo ">> [1/4] 공유 산출물 가져오기 (빌드 없음, cp 만): $SHARED_BUCKET"
-aws s3 cp "s3://$SHARED_BUCKET/copilot/injector.zip" "s3://$CODE_BUCKET/copilot/injector.zip" --region "$REGION"
-aws s3 cp "s3://$SHARED_BUCKET/copilot/layer.zip"    "s3://$CODE_BUCKET/copilot/layer.zip"    --region "$REGION"
-
-echo ">> [2/4] coffee-serverless 배선 읽기"
+echo ">> [1/3] coffee-serverless 배선 읽기"
 out() { aws cloudformation describe-stacks --stack-name "$COFFEE_STACK" --region "$REGION" \
   --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" --output text; }
 res() { aws cloudformation describe-stack-resources --stack-name "$COFFEE_STACK" --region "$REGION" \
@@ -36,7 +34,7 @@ DB_HOST="$(out DBInstanceEndpoint)"
 SUBNET1="$(res PrivateSubnet1)"; SUBNET2="$(res PrivateSubnet2)"
 LAMBDA_SG="$(res LambdaSecurityGroup)"
 
-echo ">> [3/4] $STACK 배포"
+echo ">> [2/3] $STACK 배포 (injector 는 공유 버킷에서 직접 참조)"
 aws cloudformation deploy \
   --template-file "$COPILOT/infra/LabBase_CF.yaml" \
   --stack-name "$STACK" --capabilities CAPABILITY_NAMED_IAM --region "$REGION" \
@@ -44,13 +42,20 @@ aws cloudformation deploy \
     "PrivateSubnetIds=${SUBNET1},${SUBNET2}" \
     "LambdaSecurityGroupId=${LAMBDA_SG}" \
     "DbHost=${DB_HOST}" \
-    "CodeBucket=${CODE_BUCKET}"
+    "CodeBucket=${CODE_BUCKET}" \
+    "ArtifactsBucket=${SHARED_BUCKET}"
 
-echo ">> [4/4] injector 코드 강제 갱신 (같은 S3 키면 CFN이 안 끌어오므로)"
-aws lambda update-function-code --function-name coffee-fault-injector --region "$REGION" \
-  --s3-bucket "$CODE_BUCKET" --s3-key copilot/injector.zip --query LastModified --output text >/dev/null 2>&1 || true
-aws lambda wait function-updated --function-name coffee-fault-injector --region "$REGION" 2>/dev/null || true
-
-echo ">> 완료. 아래 출력값을 에이전트 Lambda 만들 때 사용하세요:"
+echo ">> [3/3] 완료. 아래 출력값을 에이전트 Lambda 만들 때 사용하세요:"
 aws cloudformation describe-stacks --stack-name "$STACK" --region "$REGION" \
   --query "Stacks[0].Outputs" --output table
+
+cat <<EOF
+
+>> [레이어는 직접 만듭니다] 공유 버킷의 layer.zip 으로 Lambda 레이어를 콘솔에서 생성:
+   Lambda → Layers → Create layer → Upload a file from Amazon S3
+
+   Amazon S3 링크 URL : https://${SHARED_BUCKET}.s3.${REGION}.amazonaws.com/copilot/layer.zip
+   호환 런타임         : Python 3.12
+
+   만든 레이어의 ARN(=DepsLayerArn)을 에이전트 Lambda 에 추가하세요.
+EOF

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -34,19 +34,32 @@ aws s3api put-bucket-policy --bucket "$SHARED_BUCKET" --region "$REGION" --polic
     "Effect": "Allow",
     "Principal": "*",
     "Action": "s3:GetObject",
-    "Resource": "arn:aws:s3:::${SHARED_BUCKET}/copilot/*"
+    "Resource": [
+      "arn:aws:s3:::${SHARED_BUCKET}/copilot/*",
+      "arn:aws:s3:::${SHARED_BUCKET}/coffee/*"
+    ]
   }]
 }
 JSON
 )"
 
-echo ">> [2/4] injector.zip 빌드 (Node)"
+echo ">> [2/5] coffee 마이크로서비스 빌드 (Node) → coffee/customer.zip, coffee/employee.zip"
+COFFEE_SRC="$(cd "$COPILOT/.." && pwd)/lambda_code/microservice"
+for svc in customer employee; do
+  CSV="$(mktemp -d)"
+  cp -r "$COFFEE_SRC/$svc/." "$CSV/"
+  ( cd "$CSV" && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1 && zip -qr "/tmp/coffee-$svc.zip" . -x "*.git*" )
+  aws s3 cp "/tmp/coffee-$svc.zip" "s3://$SHARED_BUCKET/coffee/$svc.zip" --region "$REGION"
+  rm -rf "$CSV" "/tmp/coffee-$svc.zip"
+done
+
+echo ">> [3/5] injector.zip 빌드 (Node)"
 INJ="$(mktemp -d)"
 cp -r "$COPILOT/faults/injector_lambda/." "$INJ/"
 ( cd "$INJ" && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1 && zip -qr /tmp/injector.zip . )
 aws s3 cp /tmp/injector.zip "s3://$SHARED_BUCKET/copilot/injector.zip" --region "$REGION"
 
-echo ">> [3/4] layer.zip 빌드 (Python, linux wheels)"
+echo ">> [4/5] layer.zip 빌드 (Python, linux wheels)"
 LYR="$(mktemp -d)"; mkdir -p "$LYR/python"
 python3 -m pip install -r "$COPILOT/requirements.txt" -t "$LYR/python" \
   --platform manylinux2014_x86_64 --python-version 3.12 --only-binary=:all: --quiet
@@ -54,15 +67,16 @@ rm -rf "$LYR/python"/boto3 "$LYR/python"/botocore "$LYR/python"/boto3-* "$LYR/py
 ( cd "$LYR" && zip -qr /tmp/layer.zip . -x "*.pyc" "*/__pycache__/*" )
 aws s3 cp /tmp/layer.zip "s3://$SHARED_BUCKET/copilot/layer.zip" --region "$REGION"
 
-echo ">> [4/4] 정리"
+echo ">> [5/5] 정리"
 rm -rf "$INJ" "$LYR" /tmp/injector.zip /tmp/layer.zip
 
 cat <<EOF
 
->> 발행 완료. 수강생에게 아래 공유 버킷 이름을 안내하세요:
+>> 발행 완료. 공유 버킷($SHARED_BUCKET)에 올라간 것:
+   coffee/customer.zip  coffee/employee.zip   (ServerlessApp_CF Lambda 코드)
+   copilot/injector.zip                       (LabBase 장애 주입기 코드)
+   copilot/layer.zip                          (학생이 콘솔에서 레이어로 생성)
 
-   SHARED_BUCKET = $SHARED_BUCKET
-
-   수강생은 deploy_labbase.sh 가 이 버킷에서 자동으로 cp 합니다
-   (기본값이 다르면: SHARED_BUCKET=$SHARED_BUCKET ./infra/deploy_labbase.sh).
+   수강생에게 공유 버킷명을 안내하세요: SHARED_BUCKET = $SHARED_BUCKET
+   (기본값과 다르면 ServerlessApp_CF / deploy_labbase 에 CodeBucket·SHARED_BUCKET 로 전달)
 EOF

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+###############################################################################
+# 공유 산출물 발행 (강사 1회).
+# 무거운 빌드 산출물(injector.zip / layer.zip)을 강사가 한 번만 빌드해서
+# 퍼블릭 읽기 공유 버킷에 올려둡니다. 수강생은 빌드 없이 `aws s3 cp` 로만 가져갑니다.
+#   - injector.zip : Node(mysql2) 의존성 포함 장애 주입 Lambda
+#   - layer.zip    : Python 의존성 레이어(Strands/fastapi/uvicorn/mcp/awslabs...)
+#
+# 사용: ./infra/publish_artifacts.sh [region]
+# (옵션) SHARED_BUCKET=내-공유버킷 ./infra/publish_artifacts.sh
+###############################################################################
+set -euo pipefail
+
+REGION="${1:-${AWS_REGION:-ap-northeast-2}}"
+ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COPILOT="$(cd "$HERE/.." && pwd)"
+SHARED_BUCKET="${SHARED_BUCKET:-copilot-artifacts-${ACCOUNT}-apne2}"
+
+echo ">> [1/4] 공유 버킷 준비: $SHARED_BUCKET (퍼블릭 읽기)"
+if ! aws s3api head-bucket --bucket "$SHARED_BUCKET" --region "$REGION" 2>/dev/null; then
+  aws s3api create-bucket --bucket "$SHARED_BUCKET" --region "$REGION" \
+    --create-bucket-configuration LocationConstraint="$REGION" >/dev/null
+fi
+# 퍼블릭 읽기 허용 (수강생이 cp 로 가져갈 수 있게)
+aws s3api put-public-access-block --bucket "$SHARED_BUCKET" --region "$REGION" \
+  --public-access-block-configuration \
+  BlockPublicAcls=false,IgnorePublicAcls=false,BlockPublicPolicy=false,RestrictPublicBuckets=false
+aws s3api put-bucket-policy --bucket "$SHARED_BUCKET" --region "$REGION" --policy "$(cat <<JSON
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Sid": "PublicReadCopilotArtifacts",
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": "s3:GetObject",
+    "Resource": "arn:aws:s3:::${SHARED_BUCKET}/copilot/*"
+  }]
+}
+JSON
+)"
+
+echo ">> [2/4] injector.zip 빌드 (Node)"
+INJ="$(mktemp -d)"
+cp -r "$COPILOT/faults/injector_lambda/." "$INJ/"
+( cd "$INJ" && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1 && zip -qr /tmp/injector.zip . )
+aws s3 cp /tmp/injector.zip "s3://$SHARED_BUCKET/copilot/injector.zip" --region "$REGION"
+
+echo ">> [3/4] layer.zip 빌드 (Python, linux wheels)"
+LYR="$(mktemp -d)"; mkdir -p "$LYR/python"
+python3 -m pip install -r "$COPILOT/requirements.txt" -t "$LYR/python" \
+  --platform manylinux2014_x86_64 --python-version 3.12 --only-binary=:all: --quiet
+rm -rf "$LYR/python"/boto3 "$LYR/python"/botocore "$LYR/python"/boto3-* "$LYR/python"/botocore-*
+( cd "$LYR" && zip -qr /tmp/layer.zip . -x "*.pyc" "*/__pycache__/*" )
+aws s3 cp /tmp/layer.zip "s3://$SHARED_BUCKET/copilot/layer.zip" --region "$REGION"
+
+echo ">> [4/4] 정리"
+rm -rf "$INJ" "$LYR" /tmp/injector.zip /tmp/layer.zip
+
+cat <<EOF
+
+>> 발행 완료. 수강생에게 아래 공유 버킷 이름을 안내하세요:
+
+   SHARED_BUCKET = $SHARED_BUCKET
+
+   수강생은 deploy_labbase.sh 가 이 버킷에서 자동으로 cp 합니다
+   (기본값이 다르면: SHARED_BUCKET=$SHARED_BUCKET ./infra/deploy_labbase.sh).
+EOF

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -15,7 +15,7 @@ REGION="${1:-${AWS_REGION:-ap-northeast-2}}"
 ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COPILOT="$(cd "$HERE/.." && pwd)"
-SHARED_BUCKET="${SHARED_BUCKET:-copilot-artifacts-${ACCOUNT}-apne2}"
+SHARED_BUCKET="${SHARED_BUCKET:-samsung-cloud-architect}"
 
 echo ">> [1/4] 공유 버킷 준비: $SHARED_BUCKET (퍼블릭 읽기)"
 if ! aws s3api head-bucket --bucket "$SHARED_BUCKET" --region "$REGION" 2>/dev/null; then

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -17,7 +17,7 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COPILOT="$(cd "$HERE/.." && pwd)"
 SHARED_BUCKET="${SHARED_BUCKET:-samsung-cloud-architect}"
 
-echo ">> [1/4] 공유 버킷 준비: $SHARED_BUCKET (퍼블릭 읽기)"
+echo ">> [1/5] 공유 버킷 준비: $SHARED_BUCKET (퍼블릭 읽기)"
 if ! aws s3api head-bucket --bucket "$SHARED_BUCKET" --region "$REGION" 2>/dev/null; then
   aws s3api create-bucket --bucket "$SHARED_BUCKET" --region "$REGION" \
     --create-bucket-configuration LocationConstraint="$REGION" >/dev/null

--- a/agent_sre/lambda_src/m2_tools.py
+++ b/agent_sre/lambda_src/m2_tools.py
@@ -34,8 +34,8 @@ _FN = {
     "employee": os.environ.get("COFFEE_EMPLOYEE_FN", "coffee-employee"),
 }
 _CLEAN_KEY = {
-    "customer": os.environ.get("CUSTOMER_CLEAN_KEY", "lambda/customer.zip"),
-    "employee": os.environ.get("EMPLOYEE_CLEAN_KEY", "lambda/employee.zip"),
+    "customer": os.environ.get("CUSTOMER_CLEAN_KEY", "coffee/customer.zip"),
+    "employee": os.environ.get("EMPLOYEE_CLEAN_KEY", "coffee/employee.zip"),
 }
 
 

--- a/cloudformation/ServerlessApp_CF.yaml
+++ b/cloudformation/ServerlessApp_CF.yaml
@@ -7,14 +7,15 @@ Description: >
 Parameters:
   CodeBucket:
     Type: String
-    Description: S3 bucket holding the packaged Lambda zips (created by utils/package_lambda.sh)
+    Default: samsung-cloud-architect
+    Description: 패키지된 Lambda zip 이 있는 버킷 (강사 공유 버킷 — 미리 만들 필요 없음)
   CustomerCodeKey:
     Type: String
-    Default: lambda/customer.zip
+    Default: coffee/customer.zip
     Description: S3 key of the customer Lambda package
   EmployeeCodeKey:
     Type: String
-    Default: lambda/employee.zip
+    Default: coffee/employee.zip
     Description: S3 key of the employee Lambda package
   DBUsername:
     Type: String


### PR DESCRIPTION
## 요약
CloudShell 사양·용량 부담을 없애기 위해 무거운 빌드를 강사 1회로 모으고, 학생은 공유 버킷(`samsung-cloud-architect`)을 참조만 하도록 전환. 발행은 GitHub Actions로 자동화.

## 변경
- **빌드→s3 참조 전환**: injector·의존성 레이어·coffee Lambda 코드를 강사가 1회 빌드해 공유 버킷에 발행. 학생은 빌드/복사 없이 참조.
  - 레이어는 학생이 콘솔에서 layer.zip S3 링크로 직접 생성
  - injector 는 LabBase_CF 가 공유 버킷에서 직접 참조
  - coffee Lambda 코드도 ServerlessApp_CF 가 공유 버킷에서 직접 참조 → **코드 버킷 생성 불필요**(파라미터 없이 배포)
- **CI/CD**: `.github/workflows/publish-artifacts.yml` — org secrets(`HYU_DDPS_AWS_ID`/`HYU_DDPS_AWS_SECRET`)로 인증, `publish_artifacts.sh` 실행 후 S3 산출물 검증. master 머지 시 자동 발행 + 수동 실행.
- 문서(README·STUDENT_GUIDE·INSTRUCTOR_SETUP) 분담표·절차 갱신.

## 검증
- 로컬(버킷 소유 계정 786382940258)에서 `publish_artifacts.sh` 실행 → 4개 산출물 업로드 확인: coffee/customer.zip(2.4MB), coffee/employee.zip(2.4MB), copilot/injector.zip(1.1MB), copilot/layer.zip(14MB)
- 퍼블릭 읽기 인증 없이 HTTP 206 확인 (콘솔 레이어 생성/교차계정 참조 가능)
- 워크플로 YAML 파싱 검증, ServerlessApp_CF/LabBase_CF `validate-template` 통과