### PR TITLE
chore: SRE 실습 Python 런타임 3.12 → 3.14 상향

### DIFF
--- a/agent_sre/docs/STUDENT_GUIDE.md
+++ b/agent_sre/docs/STUDENT_GUIDE.md
@@ -78,7 +78,7 @@ cd agent_sre
 2. Name: `copilot-deps`
 3. **Upload a file from Amazon S3** 선택 → S3 링크 URL 붙여넣기:
    `https://samsung-cloud-architect.s3.ap-northeast-2.amazonaws.com/copilot/layer.zip`
-4. Compatible runtimes: **Python 3.12**
+4. Compatible runtimes: **Python 3.14**
 5. Create → 만들어진 **레이어 버전 ARN(`DepsLayerArn`)** 을 메모(4-4에서 사용)
 
 ---
@@ -128,7 +128,7 @@ CloudShell에서 만든 `function.zip` 을 콘솔에 올리려면 내 PC로 내�
 
 ### 4-2. 함수 생성
 - **Lambda 콘솔 → Create function → Author from scratch**
-- Name: `strands-incident-copilot`, Runtime: **Python 3.12**, Arch: **x86_64**
+- Name: `strands-incident-copilot`, Runtime: **Python 3.14**, Arch: **x86_64**
 - **Change default execution role → Use an existing role →** `AgentRoleArn`(1번)
 - Create → **Code → Upload from → .zip** → `function.zip`
 

--- a/agent_sre/infra/deploy_labbase.sh
+++ b/agent_sre/infra/deploy_labbase.sh
@@ -54,7 +54,7 @@ cat <<EOF
    Lambda → Layers → Create layer → Upload a file from Amazon S3
 
    Amazon S3 링크 URL : https://${SHARED_BUCKET}.s3.${REGION}.amazonaws.com/copilot/layer.zip
-   호환 런타임         : Python 3.12
+   호환 런타임         : Python 3.14
 
    만든 레이어의 ARN(=DepsLayerArn)을 에이전트 Lambda 에 추가하세요.
 EOF

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -62,7 +62,7 @@ aws s3 cp /tmp/injector.zip "s3://$SHARED_BUCKET/copilot/injector.zip" --region 
 echo ">> [4/5] layer.zip 빌드 (Python, linux wheels)"
 LYR="$(mktemp -d)"; mkdir -p "$LYR/python"
 python3 -m pip install -r "$COPILOT/requirements.txt" -t "$LYR/python" \
-  --platform manylinux2014_x86_64 --python-version 3.12 --only-binary=:all: --quiet
+  --platform manylinux2014_x86_64 --python-version 3.14 --only-binary=:all: --quiet
 rm -rf "$LYR/python"/boto3 "$LYR/python"/botocore "$LYR/python"/boto3-* "$LYR/python"/botocore-*
 ( cd "$LYR" && zip -qr /tmp/layer.zip . -x "*.pyc" "*/__pycache__/*" )
 aws s3 cp /tmp/layer.zip "s3://$SHARED_BUCKET/copilot/layer.zip" --region "$REGION"

--- a/agent_sre/lambda_src/m5_aws_docs.py
+++ b/agent_sre/lambda_src/m5_aws_docs.py
@@ -22,7 +22,7 @@ def load():
         _client = MCPClient(
             lambda: stdio_client(
                 StdioServerParameters(
-                    command=os.environ.get("MCP_PYTHON", "python3.12"),
+                    command=os.environ.get("MCP_PYTHON", "python3.14"),
                     args=["-m", "awslabs.aws_documentation_mcp_server.server"],
                     env=env,
                 )

--- a/agent_sre/lambda_src/run.sh
+++ b/agent_sre/lambda_src/run.sh
@@ -5,4 +5,4 @@
 # agent_app.build_agent.
 PATH=$PATH:$LAMBDA_TASK_ROOT/bin \
 PYTHONPATH=$PYTHONPATH:$LAMBDA_TASK_ROOT:/opt/python:$LAMBDA_RUNTIME_DIR \
-    exec python3.12 -m uvicorn lambda_src.runtime:app --host 0.0.0.0 --port "${PORT:-8000}"
+    exec python3.14 -m uvicorn lambda_src.runtime:app --host 0.0.0.0 --port "${PORT:-8000}"


### PR DESCRIPTION
## 요약
Lambda 가 2025-11 부터 Python 3.14 managed runtime 을 지원하므로 실습 런타임을 3.14 로 상향.

## 변경
- `publish_artifacts.sh`: 레이어 빌드 `--python-version 3.14`
- `run.sh` / `m5_aws_docs.py`: `python3.12` → `python3.14`
- `STUDENT_GUIDE` / `deploy_labbase`: Runtime·Compatible runtime **Python 3.14**

## 검증
- `requirements.txt` 전체가 cp314/abi3/pure 휠로 해석·빌드 성공
- layer.zip 에 `pydantic_core ... cpython-314 .so` 포함, **cp312 산출물 0개**
- 4개 산출물 발행 + 퍼블릭 읽기(HTTP 206) 재확인