### PR TITLE
Agent 실습 1차 완료 (리소스 구축 과정 수행 및 f1 주입 해결까지)

### DIFF
--- a/agent_sre/faults/restore.sh
+++ b/agent_sre/faults/restore.sh
@@ -22,7 +22,8 @@ invoke_injector() {
 }
 
 redeploy_clean() {
-  local svc="$1" fn="coffee-$svc"
+  local svc="$1"
+  local fn="coffee-$svc"
   local work; work="$(mktemp -d)"
   cp -r "$SRC/$svc/." "$work/"
   ( cd "$work" && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1 )

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -29,18 +29,37 @@ aws s3api put-public-access-block --bucket "$SHARED_BUCKET" --region "$REGION" \
 aws s3api put-bucket-policy --bucket "$SHARED_BUCKET" --region "$REGION" --policy "$(cat <<JSON
 {
   "Version": "2012-10-17",
-  "Statement": [{
-    "Sid": "PublicReadCopilotArtifacts",
-    "Effect": "Allow",
-    "Principal": "*",
-    "Action": "s3:GetObject",
-    "Resource": [
-      "arn:aws:s3:::${SHARED_BUCKET}/copilot/*",
-      "arn:aws:s3:::${SHARED_BUCKET}/coffee/*",
-      "arn:aws:s3:::${SHARED_BUCKET}/cloudformation/*",
-      "arn:aws:s3:::${SHARED_BUCKET}/frontend/*"
-    ]
-  }]
+  "Statement": [
+    {
+      "Sid": "PublicReadCopilotArtifacts",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:GetObject",
+      "Resource": [
+        "arn:aws:s3:::${SHARED_BUCKET}/copilot/*",
+        "arn:aws:s3:::${SHARED_BUCKET}/coffee/*",
+        "arn:aws:s3:::${SHARED_BUCKET}/cloudformation/*",
+        "arn:aws:s3:::${SHARED_BUCKET}/frontend/*"
+      ]
+    },
+    {
+      "Sid": "PublicListCopilotArtifacts",
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "s3:ListBucket",
+      "Resource": "arn:aws:s3:::${SHARED_BUCKET}",
+      "Condition": {
+        "StringLike": {
+          "s3:prefix": [
+            "copilot/*",
+            "coffee/*",
+            "cloudformation/*",
+            "frontend/*"
+          ]
+        }
+      }
+    }
+  ]
 }
 JSON
 )"

--- a/agent_sre/lambda_src/agent_app.py
+++ b/agent_sre/lambda_src/agent_app.py
@@ -34,6 +34,10 @@ def build_agent(session_id):
         #   아래 한 줄의 # 을 지우면 로그 조회·스모크테스트·복구 도구가 켜집니다.
         # tools=m2_tools.ALL,
 
+        # ── 모듈 3: 기억(메모리) 붙이기 (m3_memory.py) ──────────────────
+        #   아래 한 줄의 # 을 지우면 이전 대화를 기억합니다.
+        # session_manager=m3_memory.memory(session_id),
+
         # ── 모듈 4: 회고 지식베이스 검색 추가 (m4_knowledge_base.py) ──────
         #   위 "tools=m2_tools.ALL," 줄을 지우고, 대신 아래 줄의 # 을 지우세요.
         # tools=m2_tools.ALL + [m4_knowledge_base.search],
@@ -41,9 +45,5 @@ def build_agent(session_id):
         # ── 모듈 5: AWS 공식문서(MCP) 추가 (m5_aws_docs.py) ──────────────
         #   위 tools 줄을 지우고, 대신 아래 줄의 # 을 지우세요.
         # tools=m2_tools.ALL + [m4_knowledge_base.search] + m5_aws_docs.load(),
-
-        # ── 모듈 3: 기억(메모리) 붙이기 (m3_memory.py) ──────────────────
-        #   아래 한 줄의 # 을 지우면 이전 대화를 기억합니다.
-        # session_manager=m3_memory.memory(session_id),
     )
     return agent


### PR DESCRIPTION
수정한 것은 세 가지 입니다.

1. 공유 S3 정책에 List 권한 추가
    - S3 에 있는 js 파일들에 각 강의생들의 API 주소를 채워넣기 위해서 PLACEHOLDER 부분을 대체하는 Lambda 에 권한이 없어서 cloudformation 을 통한 리소스 구축이 실패하였습니다.
    - 이는 기존에 있었던 getObject 뿐만이 아니라, 해당 버킷의 오브젝트 폴더에 존재하는 js 파일을 읽어들이고 해당 파일을 다운로드 하기 위해서 필요했던 List 권한이 S3 에서 허용되어 있지 않았기 때문입니다.
    - 따라서 공유 S3 정책에 권한을 추가하였습니다.
2. Agent code 순서 수정
    - 단순하게 기존 agent 코드에서 모듈 순서가 2 -> 4 -> 5 -> 3 순서로 되어 있어서, 헷갈릴까봐 순서를 변경하였습니다.
3. restore shell code 버그 수정
    - injection 이후 원복을 위한 restore shell code (agent_sre/faults/restore.sh) 에서 줄바꿈 (또는 ; ) 처리가 되지 않아서 변수 할당 전 사용 문제가 있었으며, 줄바꿈을 추가해 주었습니다.