### PR TITLE
Agent 람다 코드 생성시 S3 를 사용하도록 변경

### DIFF
--- a/agent_sre/docs/STUDENT_GUIDE.md
+++ b/agent_sre/docs/STUDENT_GUIDE.md
@@ -119,19 +119,16 @@ aws s3 cp kb/data "s3://$KB_BUCKET/danluu/" --recursive   # 20건(.txt + .metada
 
 ## 4. 에이전트 Lambda 만들기 (콘솔, 직접)
 
-### 4-1. 함수 코드 zip
-```sh
-./infra/build_function_zip.sh        # function.zip 생성 (lambda_src 만, 수십 KB)
-```
-CloudShell에서 만든 `function.zip` 을 콘솔에 올리려면 내 PC로 내려받습니다:
-**CloudShell 우측 상단 Actions → Download file → `agent_sre/function.zip`**
-(경로 입력 시 홈 기준 상대경로, 예: `architect-cloud/agent_sre/function.zip`)
+### 4-1. 함수 코드 (공유 버킷에 발행됨 — 빌드·다운로드 불필요)
+에이전트 함수 코드는 강사가 공유 버킷에 올려둡니다. 아래 S3 링크 URL 을 4-2 에서 사용합니다:
+`https://samsung-cloud-architect.s3.ap-northeast-2.amazonaws.com/copilot/function.zip`
 
 ### 4-2. 함수 생성
 - **Lambda 콘솔 → Create function → Author from scratch**
 - Name: `strands-incident-copilot`, Runtime: **Python 3.14**, Arch: **x86_64**
 - **Change default execution role → Use an existing role →** `AgentRoleArn`(1번)
-- Create → **Code → Upload from → .zip** → `function.zip`
+- Create → **Code → Upload from → Amazon S3 location** → 위 `copilot/function.zip` S3 링크 붙여넣기
+  (버킷·함수 모두 `ap-northeast-2` 라 S3 로딩 가능)
 
 ### 4-3. 핸들러·리소스 (Configuration)
 - **Handler**: `lambda_src/run.sh`

--- a/agent_sre/infra/publish_artifacts.sh
+++ b/agent_sre/infra/publish_artifacts.sh
@@ -79,11 +79,14 @@ REPO_ROOT="$(cd "$COPILOT/.." && pwd)"
 aws s3 sync "$REPO_ROOT/s3_customer" "s3://$SHARED_BUCKET/frontend/customer" --delete --region "$REGION" >/dev/null
 aws s3 sync "$REPO_ROOT/s3_employee" "s3://$SHARED_BUCKET/frontend/employee" --delete --region "$REGION" >/dev/null
 
-echo ">> [3/5] injector.zip 빌드 (Node) + CF 템플릿 업로드"
+echo ">> [3/5] injector.zip + function.zip 빌드 + CF 템플릿 업로드"
 INJ="$(mktemp -d)"
 cp -r "$COPILOT/faults/injector_lambda/." "$INJ/"
 ( cd "$INJ" && npm install --omit=dev --no-audit --no-fund >/dev/null 2>&1 && zip -qr /tmp/injector.zip . )
 aws s3 cp /tmp/injector.zip "s3://$SHARED_BUCKET/copilot/injector.zip" --region "$REGION"
+# 에이전트 함수 코드(lambda_src) → copilot/function.zip (학생이 콘솔에서 S3 링크로 로드, 빌드·다운로드 불필요)
+( cd "$COPILOT" && rm -f /tmp/function.zip && zip -qr /tmp/function.zip lambda_src -x "*.pyc" "*/__pycache__/*" )
+aws s3 cp /tmp/function.zip "s3://$SHARED_BUCKET/copilot/function.zip" --region "$REGION"
 # 학생이 콘솔에서 'Amazon S3 URL' 로 바로 배포할 수 있게 CF 템플릿 3종을 cloudformation/ 로 발행
 CF_DIR="$(cd "$COPILOT/.." && pwd)/cloudformation"
 for tpl in AgentBase_CF ServerlessApp_CF HighAvailability_CF; do
@@ -99,7 +102,7 @@ rm -rf "$LYR/python"/boto3 "$LYR/python"/botocore "$LYR/python"/boto3-* "$LYR/py
 aws s3 cp /tmp/layer.zip "s3://$SHARED_BUCKET/copilot/layer.zip" --region "$REGION"
 
 echo ">> [5/5] 정리"
-rm -rf "$INJ" "$LYR" /tmp/injector.zip /tmp/layer.zip
+rm -rf "$INJ" "$LYR" /tmp/injector.zip /tmp/function.zip /tmp/layer.zip
 
 cat <<EOF
 
@@ -107,6 +110,7 @@ cat <<EOF
    coffee/customer.zip  coffee/employee.zip   (ServerlessApp_CF Lambda 코드)
    frontend/customer/*  frontend/employee/*   (정적 프론트 소스 — 스택이 자동 발행)
    copilot/injector.zip                       (AgentBase 장애 주입기 코드)
+   copilot/function.zip                       (에이전트 함수 코드 — 콘솔에서 S3 링크로 로드)
    copilot/layer.zip                          (학생이 콘솔에서 레이어로 생성)
    cloudformation/AgentBase_CF.yaml           (콘솔 S3 URL 배포)
    cloudformation/ServerlessApp_CF.yaml       (콘솔 S3 URL 배포)


### PR DESCRIPTION
기존 cloudshell 을 통해서 build 를 통하여 function.zip 을 로컬에 다운로드하고 람다에 올려서 사용하던 방식 대신 공유 s3 에 올려서 url 을 사용할 수 있도록 변경하였습니다.

따라서 publish artifact shell script 가 변경되었으며, 현재 공유 s3 에 function.zip 이 올라가있는 상태입니다.